### PR TITLE
fix-clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,6 @@
 ---
-Checks:          'clang-analyzer-*,modernize-*,bigprone-*,readability-*,portability-*,performance-*,-modernize-avoid-c-arrays,-modernize-use-nullptr,-modernize-use-trailing-return-type'
-WarningsAsErrors: 'clang-analyzer-*,modernize-*,bigprone-*,readability-*,portability-*,performance-*,-modernize-avoid-c-arrays,-modernize-use-nullptr,-modernize-use-trailing-return-type'
+Checks:          'clang-analyzer-*,modernize-*,bigprone-*,readability-*,portability-*,performance-*,-modernize-avoid-c-arrays,-modernize-use-nullptr,-modernize-use-auto, -readability-magic-numbers, -modernize-use-trailing-return-type'
+WarningsAsErrors: 'clang-analyzer-*,modernize-*,bigprone-*,readability-*,portability-*,performance-*,-modernize-avoid-c-arrays,-modernize-use-nullptr,-modernize-use-auto, -readability-magic-numbers. -modernize-use-trailing-return-type'
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false
 FormatStyle:     'file'
@@ -11,8 +11,6 @@ CheckOptions:
   - key:            readability-identifier-naming.ClassCase
     value:          CamelCase
   - key:            readability-identifier-naming.VariableCase
-    value:          camelBack
-  - key:            readability-identifier-naming.FunctionCase
     value:          camelBack
   - key:            readability-identifier-naming.ParameterCase
     value:          camelBack
@@ -29,11 +27,9 @@ CheckOptions:
   - key:            readability-identifier-naming.GlobalVariablePrefix
     value:          g_
   - key:            readability-identifier-naming.GlobalConstantCase
-    value:          UPPER_CASE
+    value:          camelBack
   - key:            readability-identifier-naming.GlobalConstantPrefix
-    value:          gs_
+    value:          gc_
   - key:            readability-identifier-naming.MacroDefinitionCase
     value:          UPPER_CASE
-  - key:            readability-identifier-naming.MacroDefinitionIgnoredRegexp
-    value:          *STM*
 ...

--- a/cmake/propolis/common.cmake
+++ b/cmake/propolis/common.cmake
@@ -30,6 +30,14 @@ function(propolis_fetch_populate)
 
         list(APPEND CMAKE_MODULE_PATH ${${PROPOLIS_L}_SOURCE_DIR}/cmake/)
         add_subdirectory(${${PROPOLIS_L}_SOURCE_DIR}/src/pheromones ${${PROPOLIS_L}_BINARY_DIR})
+
+        # Removing warnings from freertos compilation on executable target
+        if (DISABLE_EXTERNAL_WARNINGS) 
+            target_compile_options(swarmus-propolis-pheromones-hivemind-host PRIVATE -w)
+            set_target_properties(swarmus-propolis-pheromones-hivemind-host PROPERTIES CXX_CLANG_TIDY "" )
+            set_target_properties(swarmus-propolis-pheromones-hivemind-host PROPERTIES C_CLANG_TIDY "" )
+        endif()
+
     endif()
 
 endfunction()

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -51,9 +51,8 @@ int main(int argc, char** argv) {
     IBSP& bsp = BSPContainer::getBSP();
     bsp.initChip((void*)&cmdLineArgs);
 
-    const uint32_t stackSize =  configMINIMAL_STACK_SIZE * 8;
-    xTaskCreate(printThreadExample, "print", stackSize, NULL,
-                tskIDLE_PRIORITY + 1, NULL);
+    const uint32_t stackSize = configMINIMAL_STACK_SIZE * 8;
+    xTaskCreate(printThreadExample, "print", stackSize, NULL, tskIDLE_PRIORITY + 1, NULL);
 
     vTaskStartScheduler();
 

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -51,7 +51,8 @@ int main(int argc, char** argv) {
     IBSP& bsp = BSPContainer::getBSP();
     bsp.initChip((void*)&cmdLineArgs);
 
-    xTaskCreate(printThreadExample, "print", configMINIMAL_STACK_SIZE * 8, NULL,
+    const uint32_t stackSize =  configMINIMAL_STACK_SIZE * 8;
+    xTaskCreate(printThreadExample, "print", stackSize, NULL,
                 tskIDLE_PRIORITY + 1, NULL);
 
     vTaskStartScheduler();

--- a/src/bittybuzz/include/bittybuzz/BittyBuzzSystem.h
+++ b/src/bittybuzz/include/bittybuzz/BittyBuzzSystem.h
@@ -16,12 +16,12 @@ namespace BittyBuzzSystem {
     /**
      *@brief Logger used for error reception or user functions
      **/
-    extern const ILogger* logger;
+    extern const ILogger* g_logger;
 
     /**
      *@brief String resolver used for user functions
      **/
-    extern const IBittyBuzzStringResolver* stringResolver;
+    extern const IBittyBuzzStringResolver* g_stringResolver;
     /**
      *@brief Call a bittybuzz function, check the function documentation and verify if you need to
      *pass parameter via the vm stack

--- a/src/bittybuzz/include/bittybuzz/BittyBuzzVm.tpp
+++ b/src/bittybuzz/include/bittybuzz/BittyBuzzVm.tpp
@@ -15,8 +15,8 @@ BittyBuzzVm::BittyBuzzVm(const IBittyBuzzBytecode& bytecode,
     m_bytecode(bytecode), m_bsp(bsp), m_logger(logger) {
     // Init global variable
     vm = &m_bbzVm;
-    BittyBuzzSystem::logger = &logger;
-    BittyBuzzSystem::stringResolver = &stringResolver;
+    BittyBuzzSystem::g_logger = &logger;
+    BittyBuzzSystem::g_stringResolver = &stringResolver;
 
     // Init vm
     bbzvm_construct(m_bsp.getUUId());

--- a/src/bittybuzz/src/BittyBuzzSystem.cpp
+++ b/src/bittybuzz/src/BittyBuzzSystem.cpp
@@ -1,13 +1,13 @@
 #include "bittybuzz/BittyBuzzSystem.h"
 
-const ILogger* BittyBuzzSystem::logger = NULL;
-const IBittyBuzzStringResolver* BittyBuzzSystem::stringResolver = NULL;
+const ILogger* BittyBuzzSystem::g_logger = NULL;
+const IBittyBuzzStringResolver* BittyBuzzSystem::g_stringResolver = NULL;
 
 void BittyBuzzSystem::functionCall(uint16_t stringId) {
     bbzvm_pushs(stringId);
     bbzheap_idx_t l = bbzvm_stack_at(0);
     bbzvm_pop();
-    if (bbztable_get(vm->gsyms, l, &l)) {
+    if (bbztable_get(vm->gsyms, l, &l) == 1) {
         bbzvm_pushnil(); // Push self table
         bbzvm_push(l);
         bbzvm_closure_call(0);
@@ -16,8 +16,8 @@ void BittyBuzzSystem::functionCall(uint16_t stringId) {
 }
 
 void BittyBuzzSystem::errorReceiver(bbzvm_error errcode) {
-    if (BittyBuzzSystem::logger != NULL) {
-        BittyBuzzSystem::logger->log(
+    if (BittyBuzzSystem::g_logger != NULL) {
+        BittyBuzzSystem::g_logger->log(
             LogLevel::Error,
             "BittyBuzz virtual machine error, pc: %d, stackptr: %d, state: %d error code: %d \n",
             vm->pc, vm->stackptr, vm->state, errcode);

--- a/src/bittybuzz/src/BittyBuzzUserFunctions.cpp
+++ b/src/bittybuzz/src/BittyBuzzUserFunctions.cpp
@@ -14,7 +14,8 @@ void BittyBuzzUserFunctions::logString() {
     bbzobj_t* bbzString = bbzheap_obj_at(bbzvm_locals_at(1)); // NOLINT
 
     if (bbztype_isstring(*bbzString) != 1) {
-        BittyBuzzSystem::g_logger->log(LogLevel::Warn, "BittyBuzz: Wrong argument type to logString");
+        BittyBuzzSystem::g_logger->log(LogLevel::Warn,
+                                       "BittyBuzz: Wrong argument type to logString");
     }
 
     std::optional<const char*> optionString =

--- a/src/bittybuzz/src/BittyBuzzUserFunctions.cpp
+++ b/src/bittybuzz/src/BittyBuzzUserFunctions.cpp
@@ -5,7 +5,7 @@ void BittyBuzzUserFunctions::logInt() {
     bbzvm_assert_lnum(1); // NOLINT
     bbzobj_t* intVal = bbzheap_obj_at(bbzvm_locals_at(1)); // NOLINT
 
-    BittyBuzzSystem::logger->log(LogLevel::Info, "Int value: %d", intVal->i.value);
+    BittyBuzzSystem::g_logger->log(LogLevel::Info, "Int value: %d", intVal->i.value);
     bbzvm_ret0();
 }
 
@@ -14,16 +14,16 @@ void BittyBuzzUserFunctions::logString() {
     bbzobj_t* bbzString = bbzheap_obj_at(bbzvm_locals_at(1)); // NOLINT
 
     if (bbztype_isstring(*bbzString) != 1) {
-        BittyBuzzSystem::logger->log(LogLevel::Warn, "BittyBuzz: Wrong argument type to logString");
+        BittyBuzzSystem::g_logger->log(LogLevel::Warn, "BittyBuzz: Wrong argument type to logString");
     }
 
     std::optional<const char*> optionString =
-        BittyBuzzSystem::stringResolver->getString(bbzString->s.value);
+        BittyBuzzSystem::g_stringResolver->getString(bbzString->s.value);
 
     if (optionString) {
-        BittyBuzzSystem::logger->log(LogLevel::Info, "BittyBuzz: %s", optionString.value());
+        BittyBuzzSystem::g_logger->log(LogLevel::Info, "BittyBuzz: %s", optionString.value());
     } else {
-        BittyBuzzSystem::logger->log(LogLevel::Warn, "BittyBuzz: String id not found");
+        BittyBuzzSystem::g_logger->log(LogLevel::Warn, "BittyBuzz: String id not found");
     }
 
     bbzvm_ret0();

--- a/src/bittybuzz/tests/BittyBuzzBytecodeUnitTests.cpp
+++ b/src/bittybuzz/tests/BittyBuzzBytecodeUnitTests.cpp
@@ -10,14 +10,14 @@ class BittyBuzzBytecodeTestFixture : public testing::Test {
     std::array<uint8_t, 8> m_bytecodeArray;
     BittyBuzzBytecode* m_bytecode;
     LoggerInterfaceMock* m_loggerMock;
-    int logCounter = 0;
-    std::string logLastFormat;
+    int m_logCounter = 0;
+    std::string m_logLastFormat;
 
     void SetUp() override {
         for (uint8_t i = 0; i < m_bytecodeArray.size(); i++) {
             m_bytecodeArray[i] = i;
         }
-        m_loggerMock = new LoggerInterfaceMock(logCounter, logLastFormat);
+        m_loggerMock = new LoggerInterfaceMock(m_logCounter, m_logLastFormat);
         m_bytecode =
             new BittyBuzzBytecode(*m_loggerMock, m_bytecodeArray.data(), m_bytecodeArray.size());
     }
@@ -38,7 +38,7 @@ TEST_F(BittyBuzzBytecodeTestFixture, BittyBuzzBytecode_getBytecodeFetchFunction_
     for (uint8_t i = 0; i < 3; i++) {
         EXPECT_EQ(buff[i], i);
     }
-    EXPECT_EQ(logCounter, 0);
+    EXPECT_EQ(m_logCounter, 0);
 }
 
 TEST_F(BittyBuzzBytecodeTestFixture, BittyBuzzBytecode_getBytecodeFetchFunction_getLastBytes) {
@@ -52,7 +52,7 @@ TEST_F(BittyBuzzBytecodeTestFixture, BittyBuzzBytecode_getBytecodeFetchFunction_
         EXPECT_EQ(buff[i], i + m_bytecodeArray.size() - 3);
     }
 
-    EXPECT_EQ(logCounter, 0);
+    EXPECT_EQ(m_logCounter, 0);
 }
 
 TEST_F(BittyBuzzBytecodeTestFixture,
@@ -63,7 +63,7 @@ TEST_F(BittyBuzzBytecodeTestFixture,
     const uint8_t* buff = fun(0, 5);
     // Expect
     EXPECT_EQ(buff, m_bytecodeArray.data());
-    EXPECT_EQ(logCounter, 1);
+    EXPECT_EQ(m_logCounter, 1);
 }
 
 TEST_F(BittyBuzzBytecodeTestFixture,
@@ -74,7 +74,7 @@ TEST_F(BittyBuzzBytecodeTestFixture,
     const uint8_t* buff = fun(9999, 2);
     // Expect
     EXPECT_EQ(buff, m_bytecodeArray.data() + 9999);
-    EXPECT_EQ(logCounter, 1);
+    EXPECT_EQ(m_logCounter, 1);
 }
 
 TEST_F(BittyBuzzBytecodeTestFixture, BittyBuzzBytecode_getBytecodeLength_getLength) {

--- a/src/bittybuzz/tests/BittyBuzzStringResolverUnitTests.cpp
+++ b/src/bittybuzz/tests/BittyBuzzStringResolverUnitTests.cpp
@@ -8,13 +8,13 @@ class BittyBuzzStringResolverTestFixture : public testing::Test {
   protected:
     BittyBuzzStringResolver* m_stringResolver;
     LoggerInterfaceMock* m_loggerMock;
-    int logCounter = 0;
-    std::string logLastFormat;
+    int m_logCounter = 0;
+    std::string m_logLastFormat;
     std::array<std::pair<const uint16_t, const char*>, 3> m_array = {
         {{99, "hello"}, {100, "world"}, {101, "hi"}}};
 
     void SetUp() override {
-        m_loggerMock = new LoggerInterfaceMock(logCounter, logLastFormat);
+        m_loggerMock = new LoggerInterfaceMock(m_logCounter, m_logLastFormat);
         m_stringResolver =
             new BittyBuzzStringResolver(m_array.data(), m_array.size(), 99, *m_loggerMock);
     }
@@ -32,7 +32,7 @@ TEST_F(BittyBuzzStringResolverTestFixture, BittyBuzzStringResolver_getString_get
     std::optional<const char*> ret = m_stringResolver->getString(stringId);
 
     // Expect
-    EXPECT_EQ(logCounter, 0);
+    EXPECT_EQ(m_logCounter, 0);
     EXPECT_STREQ(ret.value(), m_array[1].second);
     EXPECT_EQ(ret.operator bool(), true);
 }
@@ -44,7 +44,7 @@ TEST_F(BittyBuzzStringResolverTestFixture, BittyBuzzStringResolver_getString_get
     std::optional<const char*> ret = m_stringResolver->getString(stringId);
 
     // Expect
-    EXPECT_EQ(logCounter, 0);
+    EXPECT_EQ(m_logCounter, 0);
     EXPECT_STREQ(ret.value(), m_array[0].second);
     EXPECT_EQ(ret.operator bool(), true);
 }
@@ -56,7 +56,7 @@ TEST_F(BittyBuzzStringResolverTestFixture, BittyBuzzStringResolver_getString_get
     std::optional<const char*> ret = m_stringResolver->getString(stringId);
 
     // Expect
-    EXPECT_EQ(logCounter, 0);
+    EXPECT_EQ(m_logCounter, 0);
     EXPECT_STREQ(ret.value(), m_array[2].second);
     EXPECT_EQ(ret.operator bool(), true);
 }
@@ -69,7 +69,7 @@ TEST_F(BittyBuzzStringResolverTestFixture,
     std::optional<const char*> ret = m_stringResolver->getString(stringId);
 
     // Expect
-    EXPECT_EQ(logCounter, 0);
+    EXPECT_EQ(m_logCounter, 0);
     EXPECT_EQ(ret.operator bool(), false);
 }
 
@@ -80,7 +80,7 @@ TEST_F(BittyBuzzStringResolverTestFixture, BittyBuzzStringResolver_getString_get
     std::optional<const char*> ret = m_stringResolver->getString(stringId);
 
     // Expect
-    EXPECT_EQ(logCounter, 0);
+    EXPECT_EQ(m_logCounter, 0);
     EXPECT_EQ(ret.operator bool(), false);
 }
 
@@ -99,6 +99,6 @@ TEST_F(BittyBuzzStringResolverTestFixture, BittyBuzzStringResolver_getString_get
     std::optional<const char*> ret = stringResolver.getString(stringId);
 
     // Expect
-    EXPECT_EQ(logCounter, 1);
+    EXPECT_EQ(m_logCounter, 1);
     EXPECT_EQ(ret.operator bool(), false);
 }

--- a/src/bsp/src/common/src/circular_buff.c
+++ b/src/bsp/src/common/src/circular_buff.c
@@ -37,8 +37,9 @@ uint16_t CircularBuff_getLength(const CircularBuff* circularBuff) {
         return circularBuff->m_size;
     }
 
-    if (circularBuff->m_readPos > circularBuff->m_writePos)
+    if (circularBuff->m_readPos > circularBuff->m_writePos){
         return circularBuff->m_size - (circularBuff->m_readPos - circularBuff->m_writePos);
+    }
     return circularBuff->m_writePos - circularBuff->m_readPos;
 }
 
@@ -54,11 +55,13 @@ CircularBuffRet CircularBuff_putc(CircularBuff* circularBuff, uint8_t data) {
 
     circularBuff->m_data[circularBuff->m_writePos++] = data;
 
-    if (circularBuff->m_writePos >= circularBuff->m_size)
+    if (circularBuff->m_writePos >= circularBuff->m_size) {
         circularBuff->m_writePos = 0;
+    }
 
-    if (circularBuff->m_writePos == circularBuff->m_readPos)
+    if (circularBuff->m_writePos == circularBuff->m_readPos) {
         circularBuff->m_isFull = true;
+    }
 
     return CircularBuff_Ret_Ok;
 }
@@ -88,8 +91,9 @@ CircularBuffRet CircularBuff_getc(CircularBuff* circularBuff, uint8_t* data) {
 
     *data = circularBuff->m_data[circularBuff->m_readPos++];
 
-    if (circularBuff->m_readPos >= circularBuff->m_size)
+    if (circularBuff->m_readPos >= circularBuff->m_size) {
         circularBuff->m_readPos = 0;
+    }
 
     circularBuff->m_isFull = false;
 

--- a/src/bsp/src/common/src/circular_buff.c
+++ b/src/bsp/src/common/src/circular_buff.c
@@ -37,7 +37,7 @@ uint16_t CircularBuff_getLength(const CircularBuff* circularBuff) {
         return circularBuff->m_size;
     }
 
-    if (circularBuff->m_readPos > circularBuff->m_writePos){
+    if (circularBuff->m_readPos > circularBuff->m_writePos) {
         return circularBuff->m_size - (circularBuff->m_readPos - circularBuff->m_writePos);
     }
     return circularBuff->m_writePos - circularBuff->m_readPos;

--- a/src/bsp/src/common/tests/CircularBuffTests.cpp
+++ b/src/bsp/src/common/tests/CircularBuffTests.cpp
@@ -2,15 +2,15 @@
 #include <bits/stdint-uintn.h>
 #include <gtest/gtest.h>
 
-static const uint8_t size = 8;
+static const uint8_t gc_size = 8;
 
 class CircularBuffFixture : public testing::Test {
   public:
     CircularBuff m_circularBuff;
-    uint8_t m_data[size];
+    uint8_t m_data[gc_size];
     void SetUp() override {
-        memset(m_data, 0, size);
-        CircularBuff_init(&m_circularBuff, m_data, size);
+        memset(m_data, 0, gc_size);
+        CircularBuff_init(&m_circularBuff, m_data, gc_size);
     }
     void TearDown() override {}
 };
@@ -18,7 +18,7 @@ class CircularBuffFixture : public testing::Test {
 TEST_F(CircularBuffFixture, CircularBuff_Init_Success) {
     // Given
     // Then
-    bool ret = CircularBuff_init(&m_circularBuff, m_data, size);
+    bool ret = CircularBuff_init(&m_circularBuff, m_data, gc_size);
 
     // Expect
     EXPECT_EQ(ret, true);
@@ -27,7 +27,7 @@ TEST_F(CircularBuffFixture, CircularBuff_Init_Success) {
 TEST_F(CircularBuffFixture, CircularBuff_Init_NullCircularBuff) {
     // Given
     // Then
-    bool ret = CircularBuff_init(NULL, m_data, size);
+    bool ret = CircularBuff_init(NULL, m_data, gc_size);
 
     // Expect
     EXPECT_EQ(ret, false);
@@ -36,7 +36,7 @@ TEST_F(CircularBuffFixture, CircularBuff_Init_NullCircularBuff) {
 TEST_F(CircularBuffFixture, CircularBuff_Init_NullData) {
     // Given
     // Then
-    bool ret = CircularBuff_init(&m_circularBuff, NULL, size);
+    bool ret = CircularBuff_init(&m_circularBuff, NULL, gc_size);
 
     // Expect
     EXPECT_EQ(ret, false);
@@ -83,7 +83,7 @@ TEST_F(CircularBuffFixture, CircularBuff_getFreeSize_WriteHigherThanRead) {
     uint16_t ret = CircularBuff_getFreeSize(&m_circularBuff);
 
     // Expect
-    EXPECT_EQ(ret, size - 1);
+    EXPECT_EQ(ret, gc_size - 1);
 }
 
 TEST_F(CircularBuffFixture, CircularBuff_getLength_Empty) {
@@ -103,7 +103,7 @@ TEST_F(CircularBuffFixture, CircularBuff_getLength_Full) {
     uint16_t ret = CircularBuff_getLength(&m_circularBuff);
 
     // Expect
-    EXPECT_EQ(ret, size);
+    EXPECT_EQ(ret, gc_size);
 }
 
 TEST_F(CircularBuffFixture, CircularBuff_getLength_WriteHigherThanRead) {
@@ -127,7 +127,7 @@ TEST_F(CircularBuffFixture, CircularBuff_getLength_ReadHigherThanWrite) {
     uint16_t ret = CircularBuff_getLength(&m_circularBuff);
 
     // Expect
-    EXPECT_EQ(ret, size - 1);
+    EXPECT_EQ(ret, gc_size - 1);
 }
 
 TEST_F(CircularBuffFixture, CircularBuff_isFull_Empty) {
@@ -198,57 +198,57 @@ TEST_F(CircularBuffFixture, CircularBuff_putc_Full) {
 TEST_F(CircularBuffFixture, CircularBuff_putc_LoopBuff) {
     // Given
     m_circularBuff.m_readPos = 5;
-    m_circularBuff.m_writePos = size - 1;
+    m_circularBuff.m_writePos = gc_size - 1;
 
     // Then
     CircularBuffRet ret = CircularBuff_putc(&m_circularBuff, 42);
 
     // Expect
     EXPECT_EQ(m_circularBuff.m_writePos, 0);
-    EXPECT_EQ(m_circularBuff.m_data[size - 1], 42);
+    EXPECT_EQ(m_circularBuff.m_data[gc_size - 1], 42);
     EXPECT_EQ(ret, CircularBuff_Ret_Ok);
 }
 
 TEST_F(CircularBuffFixture, CircularBuff_put_Empty) {
     // Given
-    uint8_t data[size];
-    memset(data, 42, size);
+    uint8_t data[gc_size];
+    memset(data, 42, gc_size);
 
     // Then
-    CircularBuffRet ret = CircularBuff_put(&m_circularBuff, data, (int)(size / 2));
+    CircularBuffRet ret = CircularBuff_put(&m_circularBuff, data, (int)(gc_size / 2));
 
     // Expect
-    EXPECT_EQ(m_circularBuff.m_writePos, (int)(size / 2));
-    EXPECT_EQ(m_circularBuff.m_data[size / 2 - 1], 42);
-    EXPECT_EQ(m_circularBuff.m_data[size / 2], 0);
+    EXPECT_EQ(m_circularBuff.m_writePos, (int)(gc_size / 2));
+    EXPECT_EQ(m_circularBuff.m_data[gc_size / 2 - 1], 42);
+    EXPECT_EQ(m_circularBuff.m_data[gc_size / 2], 0);
     EXPECT_EQ(ret, CircularBuff_Ret_Ok);
 }
 
 TEST_F(CircularBuffFixture, CircularBuff_put_Full) {
     // Given
     m_circularBuff.m_isFull = true;
-    uint8_t data[size];
-    memset(data, 42, size);
+    uint8_t data[gc_size];
+    memset(data, 42, gc_size);
 
     // Then
-    CircularBuffRet ret = CircularBuff_put(&m_circularBuff, data, (int)(size / 2));
+    CircularBuffRet ret = CircularBuff_put(&m_circularBuff, data, (int)(gc_size / 2));
 
     // Expect
-    EXPECT_EQ(m_circularBuff.m_data[size / 2], 0);
+    EXPECT_EQ(m_circularBuff.m_data[gc_size / 2], 0);
     EXPECT_EQ(ret, CircularBuff_Ret_SpaceErr);
 }
 
 TEST_F(CircularBuffFixture, CircularBuff_put_NotEnoughSpace) {
     // Given
     m_circularBuff.m_writePos = 1;
-    uint8_t data[size];
-    memset(data, 42, size);
+    uint8_t data[gc_size];
+    memset(data, 42, gc_size);
 
     // Then
-    CircularBuffRet ret = CircularBuff_put(&m_circularBuff, data, (int)size);
+    CircularBuffRet ret = CircularBuff_put(&m_circularBuff, data, (int)gc_size);
 
     // Expect
-    EXPECT_EQ(m_circularBuff.m_data[size / 2], 0);
+    EXPECT_EQ(m_circularBuff.m_data[gc_size / 2], 0);
     EXPECT_EQ(ret, CircularBuff_Ret_SpaceErr);
 }
 
@@ -256,15 +256,15 @@ TEST_F(CircularBuffFixture, CircularBuff_put_Loops) {
     // Given
     m_circularBuff.m_writePos = 5;
     m_circularBuff.m_readPos = 4;
-    uint8_t data[size];
-    memset(data, 42, size);
+    uint8_t data[gc_size];
+    memset(data, 42, gc_size);
 
     // Then
-    CircularBuffRet ret = CircularBuff_put(&m_circularBuff, data, (int)(size / 2));
+    CircularBuffRet ret = CircularBuff_put(&m_circularBuff, data, (int)(gc_size / 2));
 
     // Expect
     EXPECT_EQ(m_circularBuff.m_data[5], 42);
-    EXPECT_EQ(m_circularBuff.m_writePos, (5 + size / 2) % size);
+    EXPECT_EQ(m_circularBuff.m_writePos, (5 + gc_size / 2) % gc_size);
     EXPECT_EQ(ret, CircularBuff_Ret_Ok);
 }
 
@@ -297,8 +297,8 @@ TEST_F(CircularBuffFixture, CircularBuff_getc_Full) {
 TEST_F(CircularBuffFixture, CircularBuff_getc_LoopBuff) {
     // Given
     uint8_t data = 0;
-    m_circularBuff.m_data[size - 1] = 42;
-    m_circularBuff.m_readPos = size - 1;
+    m_circularBuff.m_data[gc_size - 1] = 42;
+    m_circularBuff.m_readPos = gc_size - 1;
     m_circularBuff.m_writePos = 5;
 
     // Then
@@ -312,10 +312,10 @@ TEST_F(CircularBuffFixture, CircularBuff_getc_LoopBuff) {
 
 TEST_F(CircularBuffFixture, CircularBuff_get_Empty) {
     // Given
-    uint8_t data[size];
+    uint8_t data[gc_size];
 
     // Then
-    uint16_t ret = CircularBuff_get(&m_circularBuff, data, (int)(size / 2));
+    uint16_t ret = CircularBuff_get(&m_circularBuff, data, (int)(gc_size / 2));
 
     // Expect
     EXPECT_EQ(ret, 0);
@@ -325,40 +325,40 @@ TEST_F(CircularBuffFixture, CircularBuff_get_Empty) {
 TEST_F(CircularBuffFixture, CircularBuff_get_Full) {
     // Given
     m_circularBuff.m_isFull = true;
-    uint8_t data[size];
-    memset(m_circularBuff.m_data, 42, size);
+    uint8_t data[gc_size];
+    memset(m_circularBuff.m_data, 42, gc_size);
 
     // Then
-    uint16_t ret = CircularBuff_get(&m_circularBuff, data, (int)(size / 2));
+    uint16_t ret = CircularBuff_get(&m_circularBuff, data, (int)(gc_size / 2));
 
     // Expect
     EXPECT_EQ(m_circularBuff.m_data[0], 42);
-    EXPECT_EQ(ret, (int)(size / 2));
+    EXPECT_EQ(ret, (int)(gc_size / 2));
     EXPECT_EQ(m_circularBuff.m_isFull, false);
-    EXPECT_EQ(m_circularBuff.m_readPos, (int)(size / 2));
+    EXPECT_EQ(m_circularBuff.m_readPos, (int)(gc_size / 2));
 }
 
 TEST_F(CircularBuffFixture, CircularBuff_get_Loops) {
     // Given
     m_circularBuff.m_writePos = 4;
     m_circularBuff.m_readPos = 5;
-    uint8_t data[size];
-    memset(m_circularBuff.m_data, 42, size);
+    uint8_t data[gc_size];
+    memset(m_circularBuff.m_data, 42, gc_size);
 
     // Then
-    uint16_t ret = CircularBuff_get(&m_circularBuff, data, (int)(size / 2));
+    uint16_t ret = CircularBuff_get(&m_circularBuff, data, (int)(gc_size / 2));
 
     // Expect
     EXPECT_EQ(m_circularBuff.m_data[5], 42);
-    EXPECT_EQ(m_circularBuff.m_readPos, (5 + size / 2) % size);
-    EXPECT_EQ(ret, (int)(size / 2));
+    EXPECT_EQ(m_circularBuff.m_readPos, (5 + gc_size / 2) % gc_size);
+    EXPECT_EQ(ret, (int)(gc_size / 2));
 }
 
 TEST_F(CircularBuffFixture, CircularBuff_getZeroCopy_Empty) {
     // Given
 
     // Then
-    ZeroCopyBuff ret = CircularBuff_getZeroCopy(&m_circularBuff, (int)(size / 2));
+    ZeroCopyBuff ret = CircularBuff_getZeroCopy(&m_circularBuff, (int)(gc_size / 2));
 
     // Expect
     EXPECT_EQ(ret.length, 0);
@@ -372,7 +372,7 @@ TEST_F(CircularBuffFixture, CircularBuff_getZeroCopy_Full) {
     m_circularBuff.m_isFull = true;
     m_circularBuff.m_readPos = 1;
     m_circularBuff.m_writePos = 1;
-    uint16_t readSize = (int)(size / 2);
+    uint16_t readSize = (int)(gc_size / 2);
 
     // Then
     ZeroCopyBuff ret = CircularBuff_getZeroCopy(&m_circularBuff, readSize);
@@ -408,13 +408,13 @@ TEST_F(CircularBuffFixture, CircularBuff_getZeroCopy_Loops) {
     m_circularBuff.m_writePos = 5;
     m_circularBuff.m_readPos = 6;
     m_circularBuff.m_isFull = false;
-    uint16_t readSize = (int)(size / 2);
+    uint16_t readSize = (int)(gc_size / 2);
 
     // Then
     ZeroCopyBuff ret = CircularBuff_getZeroCopy(&m_circularBuff, readSize);
 
     // Expect
-    EXPECT_EQ(ret.length, size - 6);
+    EXPECT_EQ(ret.length, gc_size - 6);
     EXPECT_EQ(ret.status, CircularBuff_Ret_Ok);
     EXPECT_EQ(ret.data, m_circularBuff.m_data + 6);
     EXPECT_EQ(m_circularBuff.m_readPos, 6);
@@ -426,7 +426,7 @@ TEST_F(CircularBuffFixture, CircularBuff_advance_Empty) {
     m_circularBuff.m_writePos = 0;
     m_circularBuff.m_readPos = 0;
     m_circularBuff.m_isFull = false;
-    uint16_t advanceSize = (int)(size / 2);
+    uint16_t advanceSize = (int)(gc_size / 2);
 
     // Then
     uint16_t ret = CircularBuff_advance(&m_circularBuff, advanceSize);
@@ -442,7 +442,7 @@ TEST_F(CircularBuffFixture, CircularBuff_advance_Full) {
     m_circularBuff.m_writePos = 1;
     m_circularBuff.m_readPos = 1;
     m_circularBuff.m_isFull = true;
-    uint16_t advanceSize = (int)(size / 2);
+    uint16_t advanceSize = (int)(gc_size / 2);
 
     // Then
     uint16_t ret = CircularBuff_advance(&m_circularBuff, advanceSize);
@@ -458,14 +458,14 @@ TEST_F(CircularBuffFixture, CircularBuff_advance_Loop) {
     m_circularBuff.m_writePos = 5;
     m_circularBuff.m_readPos = 6;
     m_circularBuff.m_isFull = true;
-    uint16_t advanceSize = (int)(size / 2);
+    uint16_t advanceSize = (int)(gc_size / 2);
 
     // Then
     uint16_t ret = CircularBuff_advance(&m_circularBuff, advanceSize);
 
     // Expect
     EXPECT_EQ(ret, advanceSize);
-    EXPECT_EQ(m_circularBuff.m_readPos, (6 + advanceSize) % size);
+    EXPECT_EQ(m_circularBuff.m_readPos, (6 + advanceSize) % gc_size);
     EXPECT_EQ(m_circularBuff.m_isFull, false);
 }
 

--- a/src/bsp/src/posix/include/TCPClient.h
+++ b/src/bsp/src/posix/include/TCPClient.h
@@ -9,7 +9,7 @@ class TCPClient : public ITCPClient {
   public:
     TCPClient(int socket, sockaddr_in address, const ILogger& logger);
 
-    ~TCPClient() override;
+    ~TCPClient() override = default;
 
     int32_t receive(uint8_t* data, uint16_t length) override;
 

--- a/src/bsp/src/posix/src/BSP.cpp
+++ b/src/bsp/src/posix/src/BSP.cpp
@@ -34,8 +34,9 @@ void exampleTopicPublish(void* param) {
     msg.text = "Hello World";
 
     std::shared_ptr<ros::NodeHandle>* nodeHandle = (std::shared_ptr<ros::NodeHandle>*)param;
+    const uint32_t queueSize = 1000;
     ros::Publisher publisher =
-        nodeHandle->get()->advertise<hive_mind::ExampleMessage>("exampleTopic", 1000);
+        nodeHandle->get()->advertise<hive_mind::ExampleMessage>("exampleTopic", queueSize);
 
     while (true) {
         publisher.publish(msg);
@@ -49,7 +50,7 @@ void BSP::initChip(void* args) {
     CmdLineArgs* cmdLineArgs = (CmdLineArgs*)args;
     ros::init(cmdLineArgs->m_argc, cmdLineArgs->m_argv, "hive_mind");
 
-    m_rosNodeHandle = std::shared_ptr<ros::NodeHandle>(new ros::NodeHandle("~"));
+    m_rosNodeHandle = std::make_shared<ros::NodeHandle>("~");
 
     TCPUartMock& tcpUart = static_cast<TCPUartMock&>(BSPContainer::getHostUart());
     int port = m_rosNodeHandle->param("uart_mock_port", 0);

--- a/src/bsp/src/posix/src/SocketContainer.cpp
+++ b/src/bsp/src/posix/src/SocketContainer.cpp
@@ -16,7 +16,8 @@ std::optional<TCPClientWrapper> SocketContainer::getHostClientSocket() {
         std::shared_ptr<ros::NodeHandle> handle = bsp.getRosNodeHandle();
 
         std::string address = handle->param("host_tcp_address", std::string("127.0.0.1"));
-        int port = handle->param("host_tcp_port", 5555);
+        const int defaultPort = 5555;
+        int port = handle->param("host_tcp_port", defaultPort);
         ILogger& logger = LoggerContainer::getLogger();
 
         std::optional<TCPClient> socket =

--- a/src/bsp/src/posix/src/TCPClient.cpp
+++ b/src/bsp/src/posix/src/TCPClient.cpp
@@ -10,7 +10,6 @@
 TCPClient::TCPClient(int socket, sockaddr_in address, const ILogger& logger) :
     m_logger(logger), m_socketFd(socket), m_address(address) {}
 
-
 int32_t TCPClient::receive(uint8_t* data, uint16_t length) {
     return ::recv(m_socketFd, data, length, 0);
 }
@@ -23,5 +22,4 @@ bool TCPClient::close() {
     m_logger.log(LogLevel::Info, "CLOSING SOCKET");
     int ret = ::close(m_socketFd);
     return ret == 0;
-
 }

--- a/src/bsp/src/posix/src/TCPClient.cpp
+++ b/src/bsp/src/posix/src/TCPClient.cpp
@@ -10,7 +10,6 @@
 TCPClient::TCPClient(int socket, sockaddr_in address, const ILogger& logger) :
     m_logger(logger), m_socketFd(socket), m_address(address) {}
 
-TCPClient::~TCPClient() {}
 
 int32_t TCPClient::receive(uint8_t* data, uint16_t length) {
     return ::recv(m_socketFd, data, length, 0);
@@ -23,8 +22,6 @@ int32_t TCPClient::send(const uint8_t* data, uint16_t length) {
 bool TCPClient::close() {
     m_logger.log(LogLevel::Info, "CLOSING SOCKET");
     int ret = ::close(m_socketFd);
-    if (ret == 0) {
-        return true;
-    }
-    return false;
+    return ret == 0;
+
 }

--- a/src/bsp/src/posix/src/TCPUartMock.cpp
+++ b/src/bsp/src/posix/src/TCPUartMock.cpp
@@ -6,7 +6,8 @@
 #include <ros/ros.h>
 #include <task.h>
 
-void TCPUartMock_listenTask(void* param) { static_cast<TCPUartMock*>(param)->waitForClient(); }
+void TCPUartMock_listenTask(void* param) { auto* test = static_cast<TCPUartMock*>(param);
+test->waitForClient(); }
 
 TCPUartMock::TCPUartMock(ILogger& logger) : m_logger(logger), m_port(0) {}
 
@@ -41,7 +42,8 @@ void TCPUartMock::openSocket(int port) {
 
     m_logger.log(LogLevel::Info, "UART TCP mock server waiting for client on port %d", m_port);
 
-    xTaskCreate(TCPUartMock_listenTask, "tcp_uart_mock_listen", configMINIMAL_STACK_SIZE * 100,
+    const uint32_t stackSize = configMINIMAL_STACK_SIZE * 100;
+    xTaskCreate(TCPUartMock_listenTask, "tcp_uart_mock_listen", stackSize,
                 (void*)this, tskIDLE_PRIORITY + 1, NULL);
 }
 
@@ -75,7 +77,7 @@ void TCPUartMock::close() const {
         ::close(m_clientFd.value());
     }
 
-    if (m_serverFd) {
+    if (m_serverFd != 0) {
         ::close(m_serverFd);
     }
 }

--- a/src/bsp/src/posix/src/TCPUartMock.cpp
+++ b/src/bsp/src/posix/src/TCPUartMock.cpp
@@ -6,8 +6,10 @@
 #include <ros/ros.h>
 #include <task.h>
 
-void TCPUartMock_listenTask(void* param) { auto* test = static_cast<TCPUartMock*>(param);
-test->waitForClient(); }
+void TCPUartMock_listenTask(void* param) {
+    auto* test = static_cast<TCPUartMock*>(param);
+    test->waitForClient();
+}
 
 TCPUartMock::TCPUartMock(ILogger& logger) : m_logger(logger), m_port(0) {}
 
@@ -43,8 +45,8 @@ void TCPUartMock::openSocket(int port) {
     m_logger.log(LogLevel::Info, "UART TCP mock server waiting for client on port %d", m_port);
 
     const uint32_t stackSize = configMINIMAL_STACK_SIZE * 100;
-    xTaskCreate(TCPUartMock_listenTask, "tcp_uart_mock_listen", stackSize,
-                (void*)this, tskIDLE_PRIORITY + 1, NULL);
+    xTaskCreate(TCPUartMock_listenTask, "tcp_uart_mock_listen", stackSize, (void*)this,
+                tskIDLE_PRIORITY + 1, NULL);
 }
 
 bool TCPUartMock::send(const uint8_t* buffer, uint16_t length) {


### PR DESCRIPTION
clang tidy was not running because of a bug with a regex, fixed here and matched the style. Removed some constraints too (namely magic numbers)