### PR TITLE
Feat/swarinfo 300 handle disconnections on uart mock

### DIFF
--- a/src/bsp/src/posix/src/BSP.cpp
+++ b/src/bsp/src/posix/src/BSP.cpp
@@ -55,7 +55,7 @@ void BSP::initChip(void* args) {
     m_rosNodeHandle = std::make_shared<ros::NodeHandle>("~");
 
     TCPUartMock& tcpUart = static_cast<TCPUartMock&>(BSPContainer::getHostUart());
-    int port = m_rosNodeHandle->param("uart_mock_port", 0);
+    int port = m_rosNodeHandle->param("uart_mock_port", 9000);
     tcpUart.openSocket(port);
 
     m_rosWatchTask.start();

--- a/src/bsp/src/posix/src/TCPUartMock.cpp
+++ b/src/bsp/src/posix/src/TCPUartMock.cpp
@@ -66,10 +66,12 @@ bool TCPUartMock::receive(uint8_t* buffer, uint16_t length) {
 
     auto ret = ::recv(m_clientFd.value(), buffer, length, MSG_WAITALL);
 
-    if (ret == 0) {
-        // TODO: If we ever want to handle client reconnection in the simulation, do it here
-        m_logger.log(LogLevel::Warn,
-                     "Error while reading UART socket. Client has probably disconnected");
+    if (ret <= 0) {
+        m_logger.log(LogLevel::Warn, "Error while reading UART socket. Client has probably "
+                                     "disconnected. Attempting reconnection...");
+        ::close(m_clientFd.value());
+        m_clientFd = {};
+        waitForClient();
     }
 
     return ret == length;

--- a/src/bsp/src/posix/src/TCPUartMock.cpp
+++ b/src/bsp/src/posix/src/TCPUartMock.cpp
@@ -71,7 +71,12 @@ bool TCPUartMock::receive(uint8_t* buffer, uint16_t length) {
                                      "disconnected. Attempting reconnection...");
         ::close(m_clientFd.value());
         m_clientFd = {};
-        waitForClient();
+        // Only return when connection has been restored.
+        while (!m_clientFd) {
+            waitForClient();
+        }
+        // Returning false since error occurred.
+        return false;
     }
 
     return ret == length;


### PR DESCRIPTION
A simple fix that blocks on disconnection until the connection has been restored. The greet functionality is not supported yet, as it needs some rework. Also, added a default port for server socket to simplify debugging.