### PR TITLE
Feat/swarinfo 383 log type of error in bbvm

### DIFF
--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -3,6 +3,7 @@
 #include <bittybuzz/BittyBuzzContainer.h>
 #include <bittybuzz/BittyBuzzFactory.h>
 #include <bittybuzz/BittyBuzzMessageHandler.h>
+#include <bittybuzz/BittyBuzzSystem.h>
 #include <bittybuzz/BittyBuzzVm.h>
 #include <bsp/BSPContainer.h>
 #include <bsp/IBSP.h>
@@ -59,7 +60,8 @@ class BittyBuzzTask : public AbstractTask<10 * configMINIMAL_STACK_SIZE> {
         std::array<std::reference_wrapper<IBittyBuzzLib>, 2> buzzLibraries{{bbzFunctions, mathLib}};
         if (!m_bittybuzzVm.init(buzzLibraries.data(), buzzLibraries.size())) {
             m_logger.log(LogLevel::Error, "BBZVM failed to initialize. state: %s err: %s",
-                         m_bittybuzzVm.getState(), m_bittybuzzVm.getError());
+                         BittyBuzzSystem::getStateString(m_bittybuzzVm.getState()),
+                         BittyBuzzSystem::getErrorString(m_bittybuzzVm.getError()));
             return;
         }
 
@@ -67,7 +69,8 @@ class BittyBuzzTask : public AbstractTask<10 * configMINIMAL_STACK_SIZE> {
 
             if (!m_bittybuzzVm.step()) {
                 m_logger.log(LogLevel::Error, "BBZVM failed to step. state: %s err: %s",
-                             m_bittybuzzVm.getState(), m_bittybuzzVm.getError());
+                             BittyBuzzSystem::getStateString(m_bittybuzzVm.getState()),
+                             BittyBuzzSystem::getErrorString(m_bittybuzzVm.getError()));
             }
             Task::delay(100);
         }

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -58,16 +58,16 @@ class BittyBuzzTask : public AbstractTask<10 * configMINIMAL_STACK_SIZE> {
         auto mathLib = BittyBuzzFactory::createBittyBuzzMathLib();
         std::array<std::reference_wrapper<IBittyBuzzLib>, 2> buzzLibraries{{bbzFunctions, mathLib}};
         if (!m_bittybuzzVm.init(buzzLibraries.data(), buzzLibraries.size())) {
-            m_logger.log(LogLevel::Error, "BBZVM failed to initialize. state: %d err: %d",
-                         m_bittybuzzVm.getSate(), m_bittybuzzVm.getError());
+            m_logger.log(LogLevel::Error, "BBZVM failed to initialize. state: %s err: %s",
+                         m_bittybuzzVm.getState(), m_bittybuzzVm.getError());
             return;
         }
 
         while (true) {
 
             if (!m_bittybuzzVm.step()) {
-                m_logger.log(LogLevel::Error, "BBZVM failed to step. state: %d err: %d",
-                             m_bittybuzzVm.getSate(), m_bittybuzzVm.getError());
+                m_logger.log(LogLevel::Error, "BBZVM failed to step. state: %s err: %s",
+                             m_bittybuzzVm.getState(), m_bittybuzzVm.getError());
             }
             Task::delay(100);
         }

--- a/src/bittybuzz/buzz_scripts/main.bzz
+++ b/src/bittybuzz/buzz_scripts/main.bzz
@@ -4,7 +4,6 @@ function move_by_buzz(arg_float1, arg_float2){
 }
 
 function init() {
-  
   var args_description = {
     .0 = {.arg_float1=0.0},
     .1 = {.arg_float2=0.0}

--- a/src/bittybuzz/include/bittybuzz/BittyBuzzSystem.h
+++ b/src/bittybuzz/include/bittybuzz/BittyBuzzSystem.h
@@ -60,6 +60,12 @@ namespace BittyBuzzSystem {
      *@param [in] errcode the error code of the received error */
     void errorReceiver(bbzvm_error errcode);
 
+    const char* getStateString(bbzvm_state state);
+
+    const char* getErrorString(bbzvm_error error);
+
+    const char* getInstructionString(bbzvm_instr instruction);
+
 } // namespace BittyBuzzSystem
 
 #endif // __BITTYBUZZSYSTEM_H_

--- a/src/bittybuzz/include/bittybuzz/BittyBuzzVm.h
+++ b/src/bittybuzz/include/bittybuzz/BittyBuzzVm.h
@@ -43,11 +43,11 @@ class BittyBuzzVm : public IBittyBuzzVm {
 
     bool step() override;
 
-    const char* getState() const override;
+    bbzvm_state getState() const override;
 
-    const char* getError() const override;
+    bbzvm_error getError() const override;
 
-    const char* getInstruction() const override;
+    bbzvm_instr getInstruction() const override;
 
   private:
     const IBittyBuzzBytecode& m_bytecode;

--- a/src/bittybuzz/include/bittybuzz/BittyBuzzVm.h
+++ b/src/bittybuzz/include/bittybuzz/BittyBuzzVm.h
@@ -43,9 +43,11 @@ class BittyBuzzVm : public IBittyBuzzVm {
 
     bool step() override;
 
-    bbzvm_state getSate() const override;
+    const char* getState() const override;
 
-    bbzvm_error getError() const override;
+    const char* getError() const override;
+
+    const char* getInstruction() const override;
 
   private:
     const IBittyBuzzBytecode& m_bytecode;

--- a/src/bittybuzz/include/bittybuzz/IBittyBuzzVm.h
+++ b/src/bittybuzz/include/bittybuzz/IBittyBuzzVm.h
@@ -23,13 +23,13 @@ class IBittyBuzzVm {
     virtual bool step() = 0;
 
     /** @brief Get the state of the vm */
-    virtual const char* getState() const = 0;
+    virtual bbzvm_state getState() const = 0;
 
     /** @brief Get the error state of the VM */
-    virtual const char* getError() const = 0;
+    virtual bbzvm_error getError() const = 0;
 
     /** @brief Get the current instruction of the VM */
-    virtual const char* getInstruction() const = 0;
+    virtual bbzvm_instr getInstruction() const = 0;
 };
 
 #endif // __IBITTYBUZZVM_H_

--- a/src/bittybuzz/include/bittybuzz/IBittyBuzzVm.h
+++ b/src/bittybuzz/include/bittybuzz/IBittyBuzzVm.h
@@ -23,10 +23,13 @@ class IBittyBuzzVm {
     virtual bool step() = 0;
 
     /** @brief Get the state of the vm */
-    virtual bbzvm_state getSate() const = 0;
+    virtual const char* getState() const = 0;
 
     /** @brief Get the error state of the VM */
-    virtual bbzvm_error getError() const = 0;
+    virtual const char* getError() const = 0;
+
+    /** @brief Get the current instruction of the VM */
+    virtual const char* getInstruction() const = 0;
 };
 
 #endif // __IBITTYBUZZVM_H_

--- a/src/bittybuzz/src/BittyBuzzSystem.cpp
+++ b/src/bittybuzz/src/BittyBuzzSystem.cpp
@@ -21,9 +21,166 @@ void BittyBuzzSystem::functionCall(uint16_t stringId) {
 
 void BittyBuzzSystem::errorReceiver(bbzvm_error errcode) {
     if (BittyBuzzSystem::g_logger != NULL) {
-        BittyBuzzSystem::g_logger->log(
-            LogLevel::Error,
-            "BittyBuzz virtual machine error, pc: %d, stackptr: %d, state: %d error code: %d \n",
-            vm->pc, vm->stackptr, vm->state, errcode);
+        bbzvm_instr instr = (bbzvm_instr) * (*vm->bcode_fetch_fun)(vm->pc - 1, 1);
+        BittyBuzzSystem::g_logger->log(LogLevel::Error,
+                                       "BittyBuzz virtual machine error, pc: %d, stackptr: %d, "
+                                       "state: %s,  error code: %s, instruction: %s \n",
+                                       vm->pc, vm->stackptr, getStateString(vm->state),
+                                       getErrorString(errcode), getInstructionString(instr));
+    }
+}
+
+const char* BittyBuzzSystem::getStateString(bbzvm_state state) {
+    switch (state) {
+    case BBZVM_STATE_NOCODE:
+        return "BBZVM_STATE_NOCODE";
+    case BBZVM_STATE_READY:
+        return "BBZVM_STATE_READY";
+    case BBZVM_STATE_STOPPED:
+        return "BBZVM_STATE_STOPPED";
+    case BBZVM_STATE_DONE:
+        return "BBZVM_STATE_DONE";
+    case BBZVM_STATE_ERROR:
+        return "BBZVM_STATE_ERROR";
+    default:
+        return "BBZVM_STATE_UNKOWN";
+    }
+}
+
+const char* BittyBuzzSystem::getErrorString(bbzvm_error error) {
+    switch (error) {
+    case BBZVM_ERROR_NONE:
+        return "BBZVM_ERROR_NONE";
+    case BBZVM_ERROR_INSTR:
+        return "BBZVM_ERROR_INSTR";
+    case BBZVM_ERROR_STACK:
+        return "BBZVM_ERROR_STACK";
+    case BBZVM_ERROR_LNUM:
+        return "BBZVM_ERROR_LNUM";
+    case BBZVM_ERROR_PC:
+        return "BBZVM_ERROR_PC";
+    case BBZVM_ERROR_FLIST:
+        return "BBZVM_ERROR_FLIST";
+    case BBZVM_ERROR_TYPE:
+        return "BBZVM_ERROR_TYPE";
+    case BBZVM_ERROR_OUTOFRANGE:
+        return "BBZVM_ERROR_OUTOFRANGE";
+    case BBZVM_ERROR_NOTIMPL:
+        return "BBZVM_ERROR_NOTIMPL";
+    case BBZVM_ERROR_RET:
+        return "BBZVM_ERROR_RET";
+    case BBZVM_ERROR_STRING:
+        return "BBZVM_ERROR_STRING";
+    case BBZVM_ERROR_SWARM:
+        return "BBZVM_ERROR_SWARM";
+    case BBZVM_ERROR_VSTIG:
+        return "BBZVM_ERROR_VSTIG";
+    case BBZVM_ERROR_MEM:
+        return "BBZVM_ERROR_MEM";
+    case BBZVM_ERROR_MATH:
+        return "BBZVM_ERROR_MATH";
+    default:
+        return "BBZVM_ERROR_UNKOWN";
+    }
+}
+
+const char* BittyBuzzSystem::getInstructionString(bbzvm_instr instruction) {
+    switch (instruction) {
+    case BBZVM_INSTR_NOP:
+        return "BBZVM_INSTR_NOP";
+    case BBZVM_INSTR_DONE:
+        return "BBZVM_INSTR_DONE";
+    case BBZVM_INSTR_PUSHNIL:
+        return "BBZVM_INSTR_PUSHNIL";
+    case BBZVM_INSTR_DUP:
+        return "BBZVM_INSTR_DUP";
+    case BBZVM_INSTR_POP:
+        return "BBZVM_INSTR_POP";
+    case BBZVM_INSTR_RET0:
+        return "BBZVM_INSTR_RET0";
+    case BBZVM_INSTR_RET1:
+        return "BBZVM_INSTR_RET1";
+    case BBZVM_INSTR_ADD:
+        return "BBZVM_INSTR_ADD";
+    case BBZVM_INSTR_SUB:
+        return "BBZVM_INSTR_SUB";
+    case BBZVM_INSTR_MUL:
+        return "BBZVM_INSTR_MUL";
+    case BBZVM_INSTR_DIV:
+        return "BBZVM_INSTR_DIV";
+    case BBZVM_INSTR_MOD:
+        return "BBZVM_INSTR_MOD";
+    case BBZVM_INSTR_POW:
+        return "BBZVM_INSTR_POW";
+    case BBZVM_INSTR_UNM:
+        return "BBZVM_INSTR_UNM";
+    case BBZVM_INSTR_LAND:
+        return "BBZVM_INSTR_LAND";
+    case BBZVM_INSTR_LOR:
+        return "BBZVM_INSTR_LOR";
+    case BBZVM_INSTR_LNOT:
+        return "BBZVM_INSTR_LNOT";
+    case BBZVM_INSTR_BAND:
+        return "BBZVM_INSTR_BAND";
+    case BBZVM_INSTR_BOR:
+        return "BBZVM_INSTR_BOR";
+    case BBZVM_INSTR_BNOT:
+        return "BBZVM_INSTR_BNOT";
+    case BBZVM_INSTR_LSHIFT:
+        return "BBZVM_INSTR_LSHIFT";
+    case BBZVM_INSTR_RSHIFT:
+        return "BBZVM_INSTR_RSHIFT";
+    case BBZVM_INSTR_EQ:
+        return "BBZVM_INSTR_EQ";
+    case BBZVM_INSTR_NEQ:
+        return "BBZVM_INSTR_NEQ";
+    case BBZVM_INSTR_GT:
+        return "BBZVM_INSTR_GT";
+    case BBZVM_INSTR_GTE:
+        return "BBZVM_INSTR_GTE";
+    case BBZVM_INSTR_LT:
+        return "BBZVM_INSTR_LT";
+    case BBZVM_INSTR_LTE:
+        return "BBZVM_INSTR_LTE";
+    case BBZVM_INSTR_GLOAD:
+        return "BBZVM_INSTR_GLOAD";
+    case BBZVM_INSTR_GSTORE:
+        return "BBZVM_INSTR_GSTORE";
+    case BBZVM_INSTR_PUSHT:
+        return "BBZVM_INSTR_PUSHT";
+    case BBZVM_INSTR_TPUT:
+        return "BBZVM_INSTR_TPUT";
+    case BBZVM_INSTR_TGET:
+        return "BBZVM_INSTR_TGET";
+    case BBZVM_INSTR_CALLC:
+        return "BBZVM_INSTR_CALLC";
+    case BBZVM_INSTR_CALLS:
+        return "BBZVM_INSTR_CALLS";
+    case BBZVM_INSTR_PUSHF:
+        return "BBZVM_INSTR_PUSHF";
+    case BBZVM_INSTR_PUSHI:
+        return "BBZVM_INSTR_PUSHI";
+    case BBZVM_INSTR_PUSHS:
+        return "BBZVM_INSTR_PUSHS";
+    case BBZVM_INSTR_PUSHCN:
+        return "BBZVM_INSTR_PUSHCN";
+    case BBZVM_INSTR_PUSHCC:
+        return "BBZVM_INSTR_PUSHCC";
+    case BBZVM_INSTR_PUSHL:
+        return "BBZVM_INSTR_PUSHL";
+    case BBZVM_INSTR_LLOAD:
+        return "BBZVM_INSTR_LLOAD";
+    case BBZVM_INSTR_LSTORE:
+        return "BBZVM_INSTR_LSTORE";
+    case BBZVM_INSTR_LREMOVE:
+        return "BBZVM_INSTR_LREMOVE";
+    case BBZVM_INSTR_JUMP:
+        return "BBZVM_INSTR_JUMP";
+    case BBZVM_INSTR_JUMPZ:
+        return "BBZVM_INSTR_JUMPZ";
+    case BBZVM_INSTR_JUMPNZ:
+        return "BBZVM_INSTR_JUMPNZ";
+    default:
+        return "BBZVM_INSTR_UNKOWN";
     }
 }

--- a/src/bittybuzz/src/BittyBuzzVm.cpp
+++ b/src/bittybuzz/src/BittyBuzzVm.cpp
@@ -113,6 +113,9 @@ const char* BittyBuzzVm::getState() const { return BittyBuzzSystem::getStateStri
 const char* BittyBuzzVm::getError() const { return BittyBuzzSystem::getErrorString(vm->error); }
 
 const char* BittyBuzzVm::getInstruction() const {
-    bbzvm_instr instr = (bbzvm_instr) * (*vm->bcode_fetch_fun)(vm->pc - 1, 1); // -1 since the PC was incremented before the error occured
+    bbzvm_instr instr =
+        (bbzvm_instr) *
+        (*vm->bcode_fetch_fun)(vm->pc - 1,
+                               1); // -1 since the PC was incremented before the error occured
     return BittyBuzzSystem::getInstructionString(instr);
 }

--- a/src/bittybuzz/src/BittyBuzzVm.cpp
+++ b/src/bittybuzz/src/BittyBuzzVm.cpp
@@ -108,14 +108,14 @@ bool BittyBuzzVm::step() {
     return false;
 }
 
-const char* BittyBuzzVm::getState() const { return BittyBuzzSystem::getStateString(vm->state); }
+bbzvm_state BittyBuzzVm::getState() const { return vm->state; }
 
-const char* BittyBuzzVm::getError() const { return BittyBuzzSystem::getErrorString(vm->error); }
+bbzvm_error BittyBuzzVm::getError() const { return vm->error; }
 
-const char* BittyBuzzVm::getInstruction() const {
+bbzvm_instr BittyBuzzVm::getInstruction() const {
     bbzvm_instr instr =
         (bbzvm_instr) *
         (*vm->bcode_fetch_fun)(vm->pc - 1,
                                1); // -1 since the PC was incremented before the error occured
-    return BittyBuzzSystem::getInstructionString(instr);
+    return instr;
 }

--- a/src/bittybuzz/src/BittyBuzzVm.cpp
+++ b/src/bittybuzz/src/BittyBuzzVm.cpp
@@ -108,5 +108,11 @@ bool BittyBuzzVm::step() {
     return false;
 }
 
-bbzvm_state BittyBuzzVm::getSate() const { return vm->state; }
-bbzvm_error BittyBuzzVm::getError() const { return vm->error; }
+const char* BittyBuzzVm::getState() const { return BittyBuzzSystem::getStateString(vm->state); }
+
+const char* BittyBuzzVm::getError() const { return BittyBuzzSystem::getErrorString(vm->error); }
+
+const char* BittyBuzzVm::getInstruction() const {
+    bbzvm_instr instr = (bbzvm_instr) * (*vm->bcode_fetch_fun)(vm->pc - 1, 1); // -1 since the PC was incremented before the error occured
+    return BittyBuzzSystem::getInstructionString(instr);
+}

--- a/src/bsp/src/posix/include/UserInterface.h
+++ b/src/bsp/src/posix/include/UserInterface.h
@@ -1,12 +1,13 @@
 #ifndef __USERINTERFACE_H_
 #define __USERINTERFACE_H_
 
+#include "bsp/IBSP.h"
 #include "bsp/IUserInterface.h"
 #include <string>
 
 class UserInterface : public IUserInterface {
   public:
-    UserInterface();
+    UserInterface(const IBSP& bsp);
     ~UserInterface() override = default;
 
     Mutex& getPrintMutex() override;
@@ -17,6 +18,7 @@ class UserInterface : public IUserInterface {
     int printLine(const char* format, va_list args) override;
 
   private:
+    const IBSP& m_bsp;
     std::string m_accumulatedString;
     Mutex m_mutex;
 };

--- a/src/bsp/src/posix/src/BSPContainer.cpp
+++ b/src/bsp/src/posix/src/BSPContainer.cpp
@@ -16,7 +16,7 @@ IBSP& BSPContainer::getBSP() {
 }
 
 IUserInterface& BSPContainer::getUserInterface() {
-    static UserInterface s_ui;
+    static UserInterface s_ui(getBSP());
     return s_ui;
 }
 

--- a/src/bsp/src/posix/src/UserInterface.cpp
+++ b/src/bsp/src/posix/src/UserInterface.cpp
@@ -2,12 +2,12 @@
 #include <cstdio>
 #include <ros/console.h>
 
-UserInterface::UserInterface() : m_mutex(10) {}
+UserInterface::UserInterface(const IBSP& bsp) : m_bsp(bsp), m_mutex(10) {}
 
 Mutex& UserInterface::getPrintMutex() { return m_mutex; }
 
 void UserInterface::flush() {
-    ROS_INFO("%s", m_accumulatedString.c_str());
+    ROS_INFO("[HM: %d] %s", m_bsp.getUUId(), m_accumulatedString.c_str());
     m_accumulatedString = "";
 }
 

--- a/src/logger/include/logger/Logger.h
+++ b/src/logger/include/logger/Logger.h
@@ -14,6 +14,8 @@ class Logger : public ILogger {
     LogRet log(LogLevel level, const char* format, ...) override;
 
   private:
+    static char logLevelToString(LogLevel logLevel);
+
     IUserInterface& m_ui;
     LogLevel m_logLevel;
 };

--- a/src/logger/src/Logger.cpp
+++ b/src/logger/src/Logger.cpp
@@ -9,7 +9,9 @@ LogRet Logger::log(LogLevel level, const char* format, ...) {
     if (level >= m_logLevel) {
         va_list args;
         va_start(args, format);
+
         LockGuard lock = LockGuard(m_ui.getPrintMutex());
+        m_ui.print("%c: ", logLevelToString(level));
         int retValue = m_ui.printLine(format, args);
         va_end(args);
         if (retValue >= 0) {
@@ -18,4 +20,19 @@ LogRet Logger::log(LogLevel level, const char* format, ...) {
         return LogRet::Error;
     }
     return LogRet::LowLevel;
+}
+
+char Logger::logLevelToString(LogLevel logLevel) {
+    switch (logLevel) {
+    case LogLevel::Debug:
+        return 'D';
+    case LogLevel::Info:
+        return 'I';
+    case LogLevel::Warn:
+        return 'W';
+    case LogLevel::Error:
+        return 'E';
+    default:
+        return 'U';
+    }
 }

--- a/src/logger/src/Logger.cpp
+++ b/src/logger/src/Logger.cpp
@@ -11,7 +11,7 @@ LogRet Logger::log(LogLevel level, const char* format, ...) {
         va_start(args, format);
 
         LockGuard lock = LockGuard(m_ui.getPrintMutex());
-        m_ui.print("%c: ", logLevelToString(level));
+        m_ui.print("[%c] ", logLevelToString(level));
         int retValue = m_ui.printLine(format, args);
         va_end(args);
         if (retValue >= 0) {

--- a/src/logger/tests/LoggerUnitTests.cpp
+++ b/src/logger/tests/LoggerUnitTests.cpp
@@ -26,7 +26,7 @@ TEST_F(LoggerTestFixture, Logger_Log_Same_Level_Log_Once) {
     LogRet ret = m_logger->log(LogLevel::Info, "Info log");
 
     // Expect
-    EXPECT_EQ(m_uiMock->m_printCallCounter, 1);
+    EXPECT_EQ(m_uiMock->m_printCallCounter, 2); // 2 since we print the log level
     EXPECT_EQ(ret, LogRet::Ok);
 }
 
@@ -36,7 +36,7 @@ TEST_F(LoggerTestFixture, Logger_Log_Higher_Level_Log_Once) {
     LogRet ret = m_logger->log(LogLevel::Error, "Error log");
 
     // Expect
-    EXPECT_EQ(m_uiMock->m_printCallCounter, 1);
+    EXPECT_EQ(m_uiMock->m_printCallCounter, 2); // 2 since we print the log level
     EXPECT_EQ(ret, LogRet::Ok);
 }
 
@@ -56,11 +56,11 @@ TEST_F(LoggerTestFixture, Logger_Log_ReleaseSemaphore) {
     LogRet ret = m_logger->log(LogLevel::Error, "Debug log");
 
     // Expect
-    EXPECT_EQ(m_uiMock->m_printCallCounter, 1);
+    EXPECT_EQ(m_uiMock->m_printCallCounter, 2);
     EXPECT_EQ(ret, LogRet::Ok);
 
     // Call a second time and see if it's a success
-    ret = m_logger->log(LogLevel::Error, "Debug log");
+    ret = m_logger->log(LogLevel::Error, "Error log");
     EXPECT_EQ(ret, LogRet::Ok);
-    EXPECT_EQ(m_uiMock->m_printCallCounter, 2);
+    EXPECT_EQ(m_uiMock->m_printCallCounter, 4);
 }


### PR DESCRIPTION
Added some more logging, the id of the HM is now shown on every print on the ROS build, makes the logging more relevant on the simulation. Buzz now logs it's error as a string. The log level is now printed, allowing the search or filtering easier using `grep` or `ripgrep`