### PR TITLE
Feat/swarinfo 418 spi stability improvments

### DIFF
--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -147,13 +147,15 @@ class MessageSenderTask : public AbstractTask<10 * configMINIMAL_STACK_SIZE> {
             HiveMindHostSerializer serializer(*m_stream);
             MessageSender messageSender(m_streamQueue, serializer, BSPContainer::getBSP(),
                                         m_logger);
-            while (m_stream->isConnected()) {
-                // Verify that we have a message to process
-                if (m_streamQueue.isEmpty()) {
-                    m_streamQueue.wait(500);
-                }
-                if (!messageSender.processAndSerialize()) {
-                    m_logger.log(LogLevel::Warn, "Fail to process/serialize in %s", m_taskName);
+            while (true) {
+                if (m_stream->isConnected()) {
+                    // Verify that we have a message to process
+                    if (m_streamQueue.isEmpty()) {
+                        m_streamQueue.wait(500);
+                    }
+                    if (!messageSender.processAndSerialize()) {
+                        m_logger.log(LogLevel::Warn, "Fail to process/serialize in %s", m_taskName);
+                    }
                 }
             }
         }

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -120,7 +120,7 @@ class MessageDispatcherTask : public AbstractTask<10 * configMINIMAL_STACK_SIZE>
     }
 };
 
-template <typename SerializerType>
+template <typename SerializerType = HiveMindHostSerializer>
 class MessageSenderTask : public AbstractTask<10 * configMINIMAL_STACK_SIZE> {
   public:
     MessageSenderTask(const char* taskName,
@@ -163,7 +163,7 @@ class MessageSenderTask : public AbstractTask<10 * configMINIMAL_STACK_SIZE> {
     }
 };
 
-template <typename SerializerType>
+template <typename SerializerType = HiveMindHostSerializer>
 class CommMonitoringTask : public AbstractTask<5 * configMINIMAL_STACK_SIZE> {
   public:
     CommMonitoringTask<SerializerType>(const char* taskName,
@@ -266,7 +266,7 @@ int main(int argc, char** argv) {
 
     static MessageDispatcherTask s_hostDispatchTask("tcp_dispatch", gc_taskNormalPriority, NULL,
                                                     MessageHandlerContainer::getHostMsgQueue());
-    static MessageSenderTask<HiveMindHostSerializer> s_hostMessageSender(
+    static MessageSenderTask s_hostMessageSender(
         "host_send", gc_taskNormalPriority, NULL, MessageHandlerContainer::getHostMsgQueue());
     static MessageDispatcherTask s_remoteDispatchTask("remote_dispatch", gc_taskNormalPriority,
                                                       NULL,
@@ -274,7 +274,7 @@ int main(int argc, char** argv) {
     static MessageSenderTask<HiveMindHostAccumulatorSerializer> s_remoteMessageSender(
         "remote_send", gc_taskNormalPriority, NULL, MessageHandlerContainer::getRemoteMsgQueue());
 
-    static CommMonitoringTask<HiveMindHostSerializer> s_hostMonitorTask(
+    static CommMonitoringTask s_hostMonitorTask(
         "host_monitor", gc_taskNormalPriority, s_hostDispatchTask, s_hostMessageSender,
         BSPContainer::getHostCommInterface);
     static CommMonitoringTask<HiveMindHostAccumulatorSerializer> s_remoteMonitorTask(

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -136,14 +136,16 @@ class MessageSenderTask : public AbstractTask<10 * configMINIMAL_STACK_SIZE> {
     ~MessageSenderTask() override = default;
 
     void setStream(ICommInterface* stream) { m_stream = stream; }
-    void setSerializer(IHiveMindHostSerializer* serializer) { m_serializer = serializer; }
+    void setSerializer(std::shared_ptr<IHiveMindHostSerializer>& serializer) {
+        m_serializer = serializer;
+    }
 
   private:
     const char* m_taskName;
     ICommInterface* m_stream;
     INotificationQueue<MessageDTO>& m_streamQueue;
     ILogger& m_logger;
-    IHiveMindHostSerializer* m_serializer = nullptr;
+    std::shared_ptr<IHiveMindHostSerializer> m_serializer = nullptr;
 
     void task() override {
         if (m_stream != NULL && m_serializer != NULL) {
@@ -200,7 +202,7 @@ class CommMonitoringTask : public AbstractTask<5 * configMINIMAL_STACK_SIZE> {
                         HiveMindHostDeserializer deserializer(commInterface);
                         GreetHandler greetHandler(*m_serializer, deserializer,
                                                   BSPContainer::getBSP());
-                        m_senderTask.setSerializer(m_serializer.get());
+                        m_senderTask.setSerializer(m_serializer);
 
                         // Handshake
                         if (greetHandler.greet()) {

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -266,17 +266,17 @@ int main(int argc, char** argv) {
 
     static MessageDispatcherTask s_hostDispatchTask("tcp_dispatch", gc_taskNormalPriority, NULL,
                                                     MessageHandlerContainer::getHostMsgQueue());
-    static MessageSenderTask s_hostMessageSender(
-        "host_send", gc_taskNormalPriority, NULL, MessageHandlerContainer::getHostMsgQueue());
+    static MessageSenderTask s_hostMessageSender("host_send", gc_taskNormalPriority, NULL,
+                                                 MessageHandlerContainer::getHostMsgQueue());
     static MessageDispatcherTask s_remoteDispatchTask("remote_dispatch", gc_taskNormalPriority,
                                                       NULL,
                                                       MessageHandlerContainer::getRemoteMsgQueue());
     static MessageSenderTask<HiveMindHostAccumulatorSerializer> s_remoteMessageSender(
         "remote_send", gc_taskNormalPriority, NULL, MessageHandlerContainer::getRemoteMsgQueue());
 
-    static CommMonitoringTask s_hostMonitorTask(
-        "host_monitor", gc_taskNormalPriority, s_hostDispatchTask, s_hostMessageSender,
-        BSPContainer::getHostCommInterface);
+    static CommMonitoringTask s_hostMonitorTask("host_monitor", gc_taskNormalPriority,
+                                                s_hostDispatchTask, s_hostMessageSender,
+                                                BSPContainer::getHostCommInterface);
     static CommMonitoringTask<HiveMindHostAccumulatorSerializer> s_remoteMonitorTask(
         "remote_monitor", gc_taskNormalPriority, s_remoteDispatchTask, s_remoteMessageSender,
         BSPContainer::getRemoteCommInterface);

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -21,6 +21,7 @@
 #include <pheromones/HiveMindHostDeserializer.h>
 #include <pheromones/HiveMindHostSerializer.h>
 
+#include <memory>
 #include <pheromones/HiveMindHostAccumulatorSerializer.h>
 
 constexpr uint16_t gc_taskNormalPriority = tskIDLE_PRIORITY + 1;
@@ -120,7 +121,6 @@ class MessageDispatcherTask : public AbstractTask<10 * configMINIMAL_STACK_SIZE>
     }
 };
 
-template <typename SerializerType = HiveMindHostSerializer>
 class MessageSenderTask : public AbstractTask<10 * configMINIMAL_STACK_SIZE> {
   public:
     MessageSenderTask(const char* taskName,
@@ -136,17 +136,18 @@ class MessageSenderTask : public AbstractTask<10 * configMINIMAL_STACK_SIZE> {
     ~MessageSenderTask() override = default;
 
     void setStream(ICommInterface* stream) { m_stream = stream; }
+    void setSerializer(IHiveMindHostSerializer* serializer) { m_serializer = serializer; }
 
   private:
     const char* m_taskName;
     ICommInterface* m_stream;
     INotificationQueue<MessageDTO>& m_streamQueue;
     ILogger& m_logger;
+    IHiveMindHostSerializer* m_serializer = nullptr;
 
     void task() override {
-        if (m_stream != NULL) {
-            SerializerType serializer(*m_stream);
-            MessageSender messageSender(m_streamQueue, serializer, BSPContainer::getBSP(),
+        if (m_stream != NULL && m_serializer != NULL) {
+            MessageSender messageSender(m_streamQueue, *m_serializer, BSPContainer::getBSP(),
                                         m_logger);
             while (true) {
                 if (m_stream->isConnected()) {
@@ -169,19 +170,22 @@ class CommMonitoringTask : public AbstractTask<5 * configMINIMAL_STACK_SIZE> {
     CommMonitoringTask<SerializerType>(const char* taskName,
                                        UBaseType_t priority,
                                        MessageDispatcherTask& dispatcherTask,
-                                       MessageSenderTask<SerializerType>& senderTask,
+                                       MessageSenderTask& senderTask,
                                        CommInterfaceGetter commInterfaceGetter) :
         AbstractTask(taskName, priority),
         m_dispatcherTask(dispatcherTask),
         m_senderTask(senderTask),
         m_commInterfaceGetter(commInterfaceGetter),
-        m_logger(LoggerContainer::getLogger()) {}
+        m_logger(LoggerContainer::getLogger()) {
+        m_serializer = std::make_shared<SerializerType>(m_commInterfaceGetter().value());
+    }
 
   private:
     MessageDispatcherTask& m_dispatcherTask;
-    MessageSenderTask<SerializerType>& m_senderTask;
+    MessageSenderTask& m_senderTask;
     CommInterfaceGetter m_commInterfaceGetter;
     ILogger& m_logger;
+    std::shared_ptr<IHiveMindHostSerializer> m_serializer;
 
     void task() override {
         while (true) {
@@ -193,9 +197,10 @@ class CommMonitoringTask : public AbstractTask<5 * configMINIMAL_STACK_SIZE> {
 
                     if (commInterface.isConnected()) {
 
-                        SerializerType serializer(commInterface);
                         HiveMindHostDeserializer deserializer(commInterface);
-                        GreetHandler greetHandler(serializer, deserializer, BSPContainer::getBSP());
+                        GreetHandler greetHandler(*m_serializer, deserializer,
+                                                  BSPContainer::getBSP());
+                        m_senderTask.setSerializer(m_serializer.get());
 
                         // Handshake
                         if (greetHandler.greet()) {
@@ -271,8 +276,8 @@ int main(int argc, char** argv) {
     static MessageDispatcherTask s_remoteDispatchTask("remote_dispatch", gc_taskNormalPriority,
                                                       NULL,
                                                       MessageHandlerContainer::getRemoteMsgQueue());
-    static MessageSenderTask<HiveMindHostAccumulatorSerializer> s_remoteMessageSender(
-        "remote_send", gc_taskNormalPriority, NULL, MessageHandlerContainer::getRemoteMsgQueue());
+    static MessageSenderTask s_remoteMessageSender("remote_send", gc_taskNormalPriority, NULL,
+                                                   MessageHandlerContainer::getRemoteMsgQueue());
 
     static CommMonitoringTask s_hostMonitorTask("host_monitor", gc_taskNormalPriority,
                                                 s_hostDispatchTask, s_hostMessageSender,

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -120,7 +120,7 @@ class MessageDispatcherTask : public AbstractTask<10 * configMINIMAL_STACK_SIZE>
     }
 };
 
-template<typename SerializerType>
+template <typename SerializerType>
 class MessageSenderTask : public AbstractTask<10 * configMINIMAL_STACK_SIZE> {
   public:
     MessageSenderTask(const char* taskName,
@@ -163,14 +163,14 @@ class MessageSenderTask : public AbstractTask<10 * configMINIMAL_STACK_SIZE> {
     }
 };
 
-template<typename SerializerType>
+template <typename SerializerType>
 class CommMonitoringTask : public AbstractTask<5 * configMINIMAL_STACK_SIZE> {
   public:
     CommMonitoringTask<SerializerType>(const char* taskName,
-                       UBaseType_t priority,
-                       MessageDispatcherTask& dispatcherTask,
-                       MessageSenderTask<SerializerType>& senderTask,
-                       CommInterfaceGetter commInterfaceGetter) :
+                                       UBaseType_t priority,
+                                       MessageDispatcherTask& dispatcherTask,
+                                       MessageSenderTask<SerializerType>& senderTask,
+                                       CommInterfaceGetter commInterfaceGetter) :
         AbstractTask(taskName, priority),
         m_dispatcherTask(dispatcherTask),
         m_senderTask(senderTask),
@@ -266,20 +266,20 @@ int main(int argc, char** argv) {
 
     static MessageDispatcherTask s_hostDispatchTask("tcp_dispatch", gc_taskNormalPriority, NULL,
                                                     MessageHandlerContainer::getHostMsgQueue());
-    static MessageSenderTask<HiveMindHostSerializer> s_hostMessageSender("host_send", gc_taskNormalPriority, NULL,
-                                                 MessageHandlerContainer::getHostMsgQueue());
+    static MessageSenderTask<HiveMindHostSerializer> s_hostMessageSender(
+        "host_send", gc_taskNormalPriority, NULL, MessageHandlerContainer::getHostMsgQueue());
     static MessageDispatcherTask s_remoteDispatchTask("remote_dispatch", gc_taskNormalPriority,
                                                       NULL,
                                                       MessageHandlerContainer::getRemoteMsgQueue());
-    static MessageSenderTask<HiveMindHostAccumulatorSerializer> s_remoteMessageSender("remote_send", gc_taskNormalPriority, NULL,
-                                                   MessageHandlerContainer::getRemoteMsgQueue());
+    static MessageSenderTask<HiveMindHostAccumulatorSerializer> s_remoteMessageSender(
+        "remote_send", gc_taskNormalPriority, NULL, MessageHandlerContainer::getRemoteMsgQueue());
 
-    static CommMonitoringTask<HiveMindHostSerializer> s_hostMonitorTask("host_monitor", gc_taskNormalPriority,
-                                                s_hostDispatchTask, s_hostMessageSender,
-                                                BSPContainer::getHostCommInterface);
-    static CommMonitoringTask<HiveMindHostAccumulatorSerializer> s_remoteMonitorTask("remote_monitor", gc_taskNormalPriority,
-                                                  s_remoteDispatchTask, s_remoteMessageSender,
-                                                  BSPContainer::getRemoteCommInterface);
+    static CommMonitoringTask<HiveMindHostSerializer> s_hostMonitorTask(
+        "host_monitor", gc_taskNormalPriority, s_hostDispatchTask, s_hostMessageSender,
+        BSPContainer::getHostCommInterface);
+    static CommMonitoringTask<HiveMindHostAccumulatorSerializer> s_remoteMonitorTask(
+        "remote_monitor", gc_taskNormalPriority, s_remoteDispatchTask, s_remoteMessageSender,
+        BSPContainer::getRemoteCommInterface);
 
     s_bittybuzzTask.start();
     s_hardwareInterlocTask.start();

--- a/src/bsp/src/stm32/include/SpiEsp.h
+++ b/src/bsp/src/stm32/include/SpiEsp.h
@@ -47,7 +47,7 @@ class SpiEsp : public ICommInterface {
         uint16_t m_payloadSize;
     } m_inboundMessage, m_outboundMessage;
 
-    std::array<uint8_t, 4*ESP_SPI_MAX_MESSAGE_LENGTH> m_data;
+    std::array<uint8_t, 4 * ESP_SPI_MAX_MESSAGE_LENGTH> m_data;
     CircularBuff m_circularBuf;
     TaskHandle_t m_receivingTaskHandle, m_sendingTaskHandle = nullptr;
     EspHeader::Header m_outboundHeader;

--- a/src/bsp/src/stm32/include/SpiEsp.h
+++ b/src/bsp/src/stm32/include/SpiEsp.h
@@ -11,7 +11,7 @@
 #include <c-common/circular_buff.h>
 
 constexpr uint8_t CRC32_SIZE = sizeof(uint32_t);
-constexpr uint16_t ESP_SPI_MAX_MESSAGE_LENGTH = (2048u - CRC32_SIZE);
+constexpr uint16_t ESP_SPI_MAX_MESSAGE_LENGTH = (512U - CRC32_SIZE);
 
 class SpiEsp : public ICommInterface {
   public:
@@ -47,7 +47,7 @@ class SpiEsp : public ICommInterface {
         uint16_t m_payloadSize;
     } m_inboundMessage, m_outboundMessage;
 
-    std::array<uint8_t, ESP_SPI_MAX_MESSAGE_LENGTH> m_data;
+    std::array<uint8_t, 4*ESP_SPI_MAX_MESSAGE_LENGTH> m_data;
     CircularBuff m_circularBuf;
     TaskHandle_t m_receivingTaskHandle, m_sendingTaskHandle = nullptr;
     EspHeader::Header m_outboundHeader;

--- a/src/bsp/src/stm32/src/SpiEsp.cpp
+++ b/src/bsp/src/stm32/src/SpiEsp.cpp
@@ -177,7 +177,7 @@ void SpiEsp::execute() {
         if (m_receivingTaskHandle != nullptr) {
             xTaskNotifyGive(m_receivingTaskHandle);
         }
-        m_logger.log(LogLevel::Error, "Error within Spi driver ESP - RX");
+        m_logger.log(LogLevel::Debug, "Error within Spi driver ESP - RX");
         break;
     }
     if (m_inboundRequest && m_txState == transmitState::IDLE) {
@@ -206,7 +206,7 @@ void SpiEsp::execute() {
             xTaskNotifyGive(m_sendingTaskHandle);
         }
         m_txState = transmitState::SENDING_HEADER;
-        m_logger.log(LogLevel::Error, "Error within Spi driver ESP - TX");
+        m_logger.log(LogLevel::Debug, "Error within Spi driver ESP - TX");
         break;
     }
 


### PR DESCRIPTION
- Fixes CommMonitoringTask that was exiting on disconnections
- Templated the serializer to choose between accumulator or standard
- Reduced RAM usage of SPI buffers

Less ram used, more stable behavior