### PR TITLE
Fix for storage allignment on H7

### DIFF
--- a/src/bsp/src/stm32/DefaultSettings.cmake
+++ b/src/bsp/src/stm32/DefaultSettings.cmake
@@ -1,4 +1,4 @@
-set_default(UUID_OVERRIDE 0)
+set_default(UUID_OVERRIDE 4)
 set_default(HOST_PORT 55551)
 set_default(HOST_IP "192.168.1.101")
 set_default(LOG_LEVEL "Info")

--- a/src/bsp/src/stm32/DefaultSettings.cmake
+++ b/src/bsp/src/stm32/DefaultSettings.cmake
@@ -1,4 +1,4 @@
-set_default(UUID_OVERRIDE 4)
+set_default(UUID_OVERRIDE 0)
 set_default(HOST_PORT 55551)
 set_default(HOST_IP "192.168.1.101")
 set_default(LOG_LEVEL "Info")

--- a/src/bsp/src/stm32/hal/src/hal_flash.c
+++ b/src/bsp/src/stm32/hal/src/hal_flash.c
@@ -22,7 +22,7 @@ bool Flash_program(uint32_t address, uint8_t* data, uint32_t size) {
     HAL_FLASH_Unlock();
 
     for (unsigned int i = 0; i < size; i += 4) {
-        if (HAL_FLASH_Program(FLASH_PROGRAM_32_BYTES, address, (uint64_t)(*data)) != HAL_OK) {
+        if (HAL_FLASH_Program(FLASH_PROGRAM_32_BITS, address, (uint64_t)(*data)) != HAL_OK) {
             HAL_FLASH_Lock();
             return false;
         }

--- a/src/bsp/src/stm32/hal/stm32f429zi/Core/Inc/hivemind_hal.h
+++ b/src/bsp/src/stm32/hal/stm32f429zi/Core/Inc/hivemind_hal.h
@@ -20,7 +20,7 @@ extern "C" {
 
 #define HUART_PRINT (&huart3)
 #define HRNG (&hrng)
-#define FLASH_PROGRAM_32_BYTES (FLASH_TYPEPROGRAM_WORD)
+#define FLASH_PROGRAM_32_BITS (FLASH_TYPEPROGRAM_WORD)
 #define HEARTBEAT_TIMER (&htim6)
 
 #define UI_INTERRUPT_Pin USER_Btn_Pin

--- a/src/bsp/src/stm32/hal/stm32h735zg/Core/Inc/hivemind_hal.h
+++ b/src/bsp/src/stm32/hal/stm32h735zg/Core/Inc/hivemind_hal.h
@@ -21,7 +21,7 @@ extern "C" {
 // TODO: change to match requirements
 #define HUART_PRINT (&huart3)
 #define HRNG (&hrng)
-#define FLASH_PROGRAM_32_BYTES (FLASH_TYPEPROGRAM_FLASHWORD)
+#define FLASH_PROGRAM_32_BITS (FLASH_TYPEPROGRAM_FLASHWORD)
 #define HEARTBEAT_TIMER (&htim13)
 
 #define UI_INTERRUPT_Pin IO_EXPANDER_INT__Pin

--- a/src/bsp/src/stm32/include/PersistantStorage.h
+++ b/src/bsp/src/stm32/include/PersistantStorage.h
@@ -2,8 +2,12 @@
 #define __PERSITEDSTORAGE_H__
 
 #include <cstdint>
-
+// This struct should be world alligned on instantiation. Use __attribute__ ((aligned (4))).
 struct PersistedStorage {
+    // The size should be a multiple of words for flash operations
+    static uint16_t getSize() {
+        return sizeof(PersistedStorage) + 4 - sizeof(PersistedStorage) % 4;
+    }
     uint16_t m_uuid;
 };
 

--- a/src/bsp/src/stm32/include/PersistantStorageManager.h
+++ b/src/bsp/src/stm32/include/PersistantStorageManager.h
@@ -21,7 +21,7 @@ class PersistantStorageManager {
     uint16_t getUUID() const;
 
   private:
-    PersistedStorage m_storage{};
+    PersistedStorage m_storage __attribute__((aligned(4))){};
     ILogger& m_logger;
 
     bool setUUID(uint16_t uuid);

--- a/src/bsp/src/stm32/src/PersistantStorageManager.cpp
+++ b/src/bsp/src/stm32/src/PersistantStorageManager.cpp
@@ -11,7 +11,7 @@ PersistantStorageManager::PersistantStorageManager(ILogger& logger) : m_logger(l
 
 void PersistantStorageManager::loadFromFlash() {
     std::memcpy(&m_storage, reinterpret_cast<const void*>(USER_DATA_FLASH_START_ADDRESS),
-                sizeof(m_storage));
+                PersistedStorage::getSize());
 
     if (UUID_OVERRIDE != 0) {
         setUUID(UUID_OVERRIDE);
@@ -41,6 +41,7 @@ bool PersistantStorageManager::saveToFlash() {
         return false;
     }
 
+    // The size is given in words
     return Flash_program(USER_DATA_FLASH_START_ADDRESS, reinterpret_cast<uint8_t*>(&m_storage),
-                         sizeof(m_storage));
+                         PersistedStorage::getSize() / 4);
 }


### PR DESCRIPTION
The storage struct used for reading and writing directly into the flash needs to be word-aligned and the read/write operations need to occur on multiples of words. This PR contains the alignment fixes. 