### PR TITLE
Fix/flash programming

### DIFF
--- a/src/bsp/src/stm32/hal/include/hal/hal_flash.h
+++ b/src/bsp/src/stm32/hal/include/hal/hal_flash.h
@@ -19,10 +19,10 @@ bool Flash_eraseSector(uint8_t sector);
  * @brief Saves data to previously erased flash
  * @param address Address at which to begin writing
  * @param data Pointer to the data to write
- * @param size Size of the data (in bytes)
+ * @param bytesLength Size of the data (in bytes)
  * @return True if successful, false otherwise
  */
-bool Flash_program(uint32_t address, uint8_t* data, uint32_t size);
+bool Flash_program(uint32_t address, uint8_t* data, uint32_t bytesLength);
 
 #ifdef __cplusplus
 }

--- a/src/bsp/src/stm32/hal/src/hal_flash.c
+++ b/src/bsp/src/stm32/hal/src/hal_flash.c
@@ -13,25 +13,3 @@ bool Flash_eraseSector(uint8_t sector) {
 
     return ret;
 }
-
-bool Flash_program(uint32_t address, uint8_t* data, uint32_t size) {
-    if (data == NULL) {
-        return false;
-    }
-
-    HAL_FLASH_Unlock();
-
-    for (unsigned int i = 0; i < size; i += 4) {
-        if (HAL_FLASH_Program(FLASH_PROGRAM_32_BITS, address, (uint64_t)(*data)) != HAL_OK) {
-            HAL_FLASH_Lock();
-            return false;
-        }
-
-        address += 4;
-        data += 4;
-    }
-
-    HAL_FLASH_Lock();
-
-    return true;
-}

--- a/src/bsp/src/stm32/hal/src/stm32f429zi/CMakeLists.txt
+++ b/src/bsp/src/stm32/hal/src/stm32f429zi/CMakeLists.txt
@@ -4,6 +4,7 @@ set(LIB_ALIAS "SwarmUS::HiveMind::HAL::STM32::Platform")
 set(LIB_SOURCES
         user_interface.c
         hal_init.c
+        hal_flash.c
     )
 
 

--- a/src/bsp/src/stm32/hal/src/stm32f429zi/hal_flash.c
+++ b/src/bsp/src/stm32/hal/src/stm32f429zi/hal_flash.c
@@ -1,6 +1,8 @@
 #include "hal/hal_flash.h"
+#include <core_cm7.h>
 
 bool Flash_program(uint32_t address, uint8_t* data, uint32_t bytesLength) {
+    SCB_InvalidateDCache();
     if (data == NULL) {
         return false;
     }
@@ -19,5 +21,6 @@ bool Flash_program(uint32_t address, uint8_t* data, uint32_t bytesLength) {
 
     HAL_FLASH_Lock();
 
+    SCB_InvalidateDCache();
     return true;
 }

--- a/src/bsp/src/stm32/hal/src/stm32f429zi/hal_flash.c
+++ b/src/bsp/src/stm32/hal/src/stm32f429zi/hal_flash.c
@@ -1,8 +1,6 @@
 #include "hal/hal_flash.h"
-#include <core_cm7.h>
 
 bool Flash_program(uint32_t address, uint8_t* data, uint32_t bytesLength) {
-    SCB_InvalidateDCache();
     if (data == NULL) {
         return false;
     }
@@ -21,6 +19,5 @@ bool Flash_program(uint32_t address, uint8_t* data, uint32_t bytesLength) {
 
     HAL_FLASH_Lock();
 
-    SCB_InvalidateDCache();
     return true;
 }

--- a/src/bsp/src/stm32/hal/src/stm32f429zi/hal_flash.c
+++ b/src/bsp/src/stm32/hal/src/stm32f429zi/hal_flash.c
@@ -1,0 +1,23 @@
+#include "hal/hal_flash.h"
+
+bool Flash_program(uint32_t address, uint8_t* data, uint32_t bytesLength) {
+    if (data == NULL) {
+        return false;
+    }
+
+    HAL_FLASH_Unlock();
+
+    for (unsigned int i = 0; i < bytesLength; i++) {
+        if (HAL_FLASH_Program(FLASH_TYPEPROGRAM_BYTE, address, (uint64_t)(*data)) != HAL_OK) {
+            HAL_FLASH_Lock();
+            return false;
+        }
+
+        address += 1;
+        data += 1;
+    }
+
+    HAL_FLASH_Lock();
+
+    return true;
+}

--- a/src/bsp/src/stm32/hal/src/stm32h735zg/CMakeLists.txt
+++ b/src/bsp/src/stm32/hal/src/stm32h735zg/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIB_SOURCES
         tca9539.c
         tca9539.h
         hal_init.c
+        hal_flash.c
     )
 
 add_library(${LIB_NAME} INTERFACE)

--- a/src/bsp/src/stm32/hal/src/stm32h735zg/hal_flash.c
+++ b/src/bsp/src/stm32/hal/src/stm32h735zg/hal_flash.c
@@ -1,6 +1,7 @@
 #include "hal/hal_flash.h"
 
 bool Flash_program(uint32_t address, uint8_t* data, uint32_t bytesLength) {
+    SCB_InvalidateDCache();
     if (data == NULL) {
         return false;
     }
@@ -24,5 +25,6 @@ bool Flash_program(uint32_t address, uint8_t* data, uint32_t bytesLength) {
 
     HAL_FLASH_Lock();
 
+    SCB_InvalidateDCache();
     return true;
 }

--- a/src/bsp/src/stm32/hal/src/stm32h735zg/hal_flash.c
+++ b/src/bsp/src/stm32/hal/src/stm32h735zg/hal_flash.c
@@ -7,6 +7,9 @@ bool Flash_program(uint32_t address, uint8_t* data, uint32_t bytesLength) {
 
     HAL_FLASH_Unlock();
 
+    // Round up to the nearest multiple of 8 bytes as the write works on 64 bit words.
+    // If we are saving less than 64 bits, we will write garbage to the Flash, but it doesn't really
+    // matter. The readback is done with a memcpy and won't read the garbage.
     uint32_t flashWordLength = (bytesLength + (sizeof(uint64_t) - 1)) / sizeof(uint64_t);
 
     for (unsigned int i = 0; i < flashWordLength; i++) {

--- a/src/bsp/src/stm32/hal/src/stm32h735zg/hal_flash.c
+++ b/src/bsp/src/stm32/hal/src/stm32h735zg/hal_flash.c
@@ -1,0 +1,25 @@
+#include "hal/hal_flash.h"
+
+bool Flash_program(uint32_t address, uint8_t* data, uint32_t bytesLength) {
+    if (data == NULL) {
+        return false;
+    }
+
+    HAL_FLASH_Unlock();
+
+    uint32_t flashWordLength = (bytesLength + (sizeof(uint64_t) - 1)) / sizeof(uint64_t);
+
+    for (unsigned int i = 0; i < flashWordLength; i++) {
+        if (HAL_FLASH_Program(FLASH_TYPEPROGRAM_FLASHWORD, address, (uint32_t)data) != HAL_OK) {
+            HAL_FLASH_Lock();
+            return false;
+        }
+
+        address += sizeof(uint64_t);
+        data += sizeof(uint64_t);
+    }
+
+    HAL_FLASH_Lock();
+
+    return true;
+}

--- a/src/bsp/src/stm32/hal/src/stm32h735zg/hal_init.c
+++ b/src/bsp/src/stm32/hal/src/stm32h735zg/hal_init.c
@@ -82,8 +82,9 @@ static void Hal_initCache() {
     /* Enable I-Cache */
     SCB_EnableICache();
 
-    /* Do not enable D-Cache as it causes a hardfault when trying to read or write to flash */
-    // SCB_DisableDCache();
+    /* Enable D-Cache */
+    SCB_EnableDCache();
+    SCB_InvalidateDCache();
 }
 
 bool Hal_wroomPowerEnabled() {

--- a/src/bsp/src/stm32/hal/src/stm32h735zg/hal_init.c
+++ b/src/bsp/src/stm32/hal/src/stm32h735zg/hal_init.c
@@ -82,8 +82,8 @@ static void Hal_initCache() {
     /* Enable I-Cache */
     SCB_EnableICache();
 
-    /* Enable D-Cache */
-    SCB_EnableDCache();
+    /* Do not enable D-Cache as it causes a hardfault when trying to read or write to flash */
+    // SCB_DisableDCache();
 }
 
 bool Hal_wroomPowerEnabled() {

--- a/src/bsp/src/stm32/hal/stm32f429zi/Core/Inc/hivemind_hal.h
+++ b/src/bsp/src/stm32/hal/stm32f429zi/Core/Inc/hivemind_hal.h
@@ -20,7 +20,6 @@ extern "C" {
 
 #define HUART_PRINT (&huart3)
 #define HRNG (&hrng)
-#define FLASH_PROGRAM_32_BITS (FLASH_TYPEPROGRAM_WORD)
 #define HEARTBEAT_TIMER (&htim6)
 
 #define UI_INTERRUPT_Pin USER_Btn_Pin

--- a/src/bsp/src/stm32/hal/stm32h735zg/Core/Inc/hivemind_hal.h
+++ b/src/bsp/src/stm32/hal/stm32h735zg/Core/Inc/hivemind_hal.h
@@ -21,7 +21,6 @@ extern "C" {
 // TODO: change to match requirements
 #define HUART_PRINT (&huart3)
 #define HRNG (&hrng)
-#define FLASH_PROGRAM_32_BITS (FLASH_TYPEPROGRAM_FLASHWORD)
 #define HEARTBEAT_TIMER (&htim13)
 
 #define UI_INTERRUPT_Pin IO_EXPANDER_INT__Pin

--- a/src/bsp/src/stm32/src/PersistantStorageManager.cpp
+++ b/src/bsp/src/stm32/src/PersistantStorageManager.cpp
@@ -43,5 +43,5 @@ bool PersistantStorageManager::saveToFlash() {
 
     // The size is given in words
     return Flash_program(USER_DATA_FLASH_START_ADDRESS, reinterpret_cast<uint8_t*>(&m_storage),
-                         PersistedStorage::getSize() / 4);
+                         PersistedStorage::getSize());
 }

--- a/tools/openocd/stm32_h7/hiveboard.cfg
+++ b/tools/openocd/stm32_h7/hiveboard.cfg
@@ -1,13 +1,9 @@
-#adapter driver ftdi
-#ftdi_vid_pid 0x0403 0x6011
-#ftdi_channel 0
-#ftdi_layout_init 0x0098 0x008b
+adapter driver ftdi
+ftdi_vid_pid 0x0403 0x6011
+ftdi_channel 0
+ftdi_layout_init 0x0098 0x008b
 #ftdi_layout_signal nSRST -data 0x0080 -noe 0x0080
-#transport select jtag
-
-source [find interface/stlink.cfg]
-transport select hla_swd
+transport select jtag
 
 source [find target/stm32h7x.cfg]
-#reset_config srst_only
 reset_config none

--- a/tools/openocd/stm32_h7/hiveboard.cfg
+++ b/tools/openocd/stm32_h7/hiveboard.cfg
@@ -1,9 +1,13 @@
-adapter driver ftdi
-ftdi_vid_pid 0x0403 0x6011
-ftdi_channel 0
-ftdi_layout_init 0x0098 0x008b
+#adapter driver ftdi
+#ftdi_vid_pid 0x0403 0x6011
+#ftdi_channel 0
+#ftdi_layout_init 0x0098 0x008b
 #ftdi_layout_signal nSRST -data 0x0080 -noe 0x0080
-transport select jtag
+#transport select jtag
+
+source [find interface/stlink.cfg]
+transport select hla_swd
 
 source [find target/stm32h7x.cfg]
+#reset_config srst_only
 reset_config none


### PR DESCRIPTION
Fix writing to flash for the H7.

- Disable D-Cache as it causes issues
- Change the function call to HAL_FLASH_Program() as it takes a pointer to the data on the H7 instead of the data itself
- Change how many bytes are written to flash as we can write single bytes on the F4, but only DoubleWords on the H7