### PR TITLE
Fixed SPI stuck on timeout for esp

### DIFF
--- a/src/bsp/src/stm32/include/SpiEsp.h
+++ b/src/bsp/src/stm32/include/SpiEsp.h
@@ -29,7 +29,7 @@ class SpiEsp : public ICommInterface {
     void execute();
 
   private:
-    BaseTask<configMINIMAL_STACK_SIZE * 6> m_driverTask;
+    BaseTask<configMINIMAL_STACK_SIZE * 10> m_driverTask;
     ICRC& m_crc;
     ILogger& m_logger;
 


### PR DESCRIPTION
For some reason, the SPI channel for the esp gets stuck on a SPI_TX_RX_BUSY, preventing it from doing further transactions. The only flag for this issue is that the Error Interrupt Enable flag is set. After reading the documentation, it is still unclear as to why and where this is set and even more obscure as to how to prevent it. A patch was made to reset the channel upon the detection that it is stuck in this state. 