### PR TITLE
Reset interloc dumps on state change

### DIFF
--- a/src/bsp/include/bsp/InterlocUpdate.h
+++ b/src/bsp/include/bsp/InterlocUpdate.h
@@ -18,6 +18,8 @@ struct InterlocUpdate {
     std::optional<float> m_angleOfArrival;
 
     std::optional<bool> m_isInLineOfSight;
+
+    bool m_resetDumps = false;
 };
 
 #endif //__INTERLOCUPDATE_H__

--- a/src/interloc/include/interloc/InterlocMessageHandler.h
+++ b/src/interloc/include/interloc/InterlocMessageHandler.h
@@ -2,6 +2,7 @@
 #define __INTERLOCMESSAGEHANDLER_H__
 
 #include "IInterlocMessageHandler.h"
+#include <INotificationQueue.h>
 #include <bsp/IBSP.h>
 #include <bsp/IInterlocManager.h>
 #include <cpp-common/ICircularQueue.h>
@@ -16,7 +17,8 @@ class InterlocMessageHandler : public IInterlocMessageHandler {
                            IBSP& bsp,
                            ICircularQueue<MessageDTO>& inputQueue,
                            ICircularQueue<MessageDTO>& hostQueue,
-                           ICircularQueue<MessageDTO>& remoteQueue);
+                           ICircularQueue<MessageDTO>& remoteQueue,
+                           INotificationQueue<InterlocUpdate>& interlocPositionUpdateQueue);
 
     virtual ~InterlocMessageHandler() = default;
 
@@ -33,6 +35,7 @@ class InterlocMessageHandler : public IInterlocMessageHandler {
     ICircularQueue<MessageDTO>& m_inputQueue;
     ICircularQueue<MessageDTO>& m_hostQueue;
     ICircularQueue<MessageDTO>& m_remoteQueue;
+    INotificationQueue<InterlocUpdate>& m_interlocPositionUpdateQueue;
 
     std::array<GetNeighborResponseDTO, InterlocDumpDTO::MAX_UPDATES_SIZE> m_updateDtoArray;
 

--- a/src/interloc/src/Interloc.cpp
+++ b/src/interloc/src/Interloc.cpp
@@ -101,15 +101,19 @@ void Interloc::process() {
     }
 
     if (auto update = m_positionUpdateInputQueue.peek()) {
-        processPositionUpdate(update->get());
-        m_updatesHistory[m_updateHistoryIdx] = update->get();
-        m_updateHistoryIdx++;
+        if (update->get().m_resetDumps) {
+            m_updateHistoryIdx = 0;
+        } else {
+            processPositionUpdate(update->get());
+            m_updatesHistory[m_updateHistoryIdx] = update->get();
+            m_updateHistoryIdx++;
+
+            if (m_updateHistoryIdx == InterlocDumpDTO::MAX_UPDATES_SIZE) {
+                dumpUpdatesHistory();
+            }
+        }
 
         m_positionUpdateInputQueue.pop();
-
-        if (m_updateHistoryIdx == InterlocDumpDTO::MAX_UPDATES_SIZE) {
-            dumpUpdatesHistory();
-        }
     }
 }
 

--- a/src/interloc/src/InterlocContainer.cpp
+++ b/src/interloc/src/InterlocContainer.cpp
@@ -21,7 +21,7 @@ IInterlocMessageHandler& InterlocContainer::getInterlocMessageHandler() {
     static InterlocMessageHandler s_messageHandler = InterlocMessageHandler(
         LoggerContainer::getLogger(), BSPContainer::getInterlocManager(), BSPContainer::getBSP(),
         MessageHandlerContainer::getInterlocMsgQueue(), MessageHandlerContainer::getHostMsgQueue(),
-        MessageHandlerContainer::getRemoteMsgQueue());
+        MessageHandlerContainer::getRemoteMsgQueue(), getInterlocUpdateInputQueue());
 
     return s_messageHandler;
 }

--- a/src/interloc/tests/InterlocMessageHandlerUnitTests.cpp
+++ b/src/interloc/tests/InterlocMessageHandlerUnitTests.cpp
@@ -4,6 +4,7 @@
 #include <mocks/CircularQueueInterfaceMock.h>
 #include <mocks/InterlocManagerInterfaceMock.h>
 #include <mocks/LoggerInterfaceMock.h>
+#include <mocks/NotificationQueueInterfaceMock.h>
 #include <pheromones/MessageDTO.h>
 
 class InterlocMessageHandlerFixture : public testing::Test {
@@ -16,12 +17,13 @@ class InterlocMessageHandlerFixture : public testing::Test {
     CircularQueueInterfaceMock<MessageDTO> m_inputQueueMock;
     CircularQueueInterfaceMock<MessageDTO> m_hostQueueMock;
     CircularQueueInterfaceMock<MessageDTO> m_remoteQueueMock;
+    NotificationQueueInterfaceMock<InterlocUpdate> m_updateQueueMock;
     BSPInterfaceMock m_bspMock = BSPInterfaceMock(gc_boardId);
 
     void SetUp() override {
-        m_messageHandler =
-            new InterlocMessageHandler(m_loggerMock, m_interlocManagerMock, m_bspMock,
-                                       m_inputQueueMock, m_hostQueueMock, m_remoteQueueMock);
+        m_messageHandler = new InterlocMessageHandler(m_loggerMock, m_interlocManagerMock,
+                                                      m_bspMock, m_inputQueueMock, m_hostQueueMock,
+                                                      m_remoteQueueMock, m_updateQueueMock);
     }
 
     void TearDown() override { delete m_messageHandler; }


### PR DESCRIPTION
Make it so when an external state change is requested, the interloc dumps are purged. This allows us extracting multiple readings at a given angle without accumulating data while we are moving between two angles